### PR TITLE
docs: fix broken link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ const Example = () => (
 [![npm](https://img.shields.io/npm/dm/@suspensive/react-query?color=000&labelColor=000)](https://www.npmjs.com/package/@suspensive/react-query)
 [![npm bundle size](https://img.shields.io/bundlephobia/minzip/@suspensive/react-query?color=000&labelColor=000)](https://www.npmjs.com/package/@suspensive/react-query)
 
-Declarative apis to use [@tanstack/react-query with suspense](https://tanstack.com/query/v4/docs/guides/suspense) easily.
+Declarative apis to use [@tanstack/react-query with suspense](https://tanstack.com/query/v4/docs/framework/react/guides/suspense) easily.
 
 ### Features
 


### PR DESCRIPTION
# Overview

|<img width="812" alt="image" src="https://github.com/toss/suspensive/assets/39869096/fb39e36b-7c47-4da3-8351-8479f8df669e">|<img width="1072" alt="image" src="https://github.com/toss/suspensive/assets/39869096/b36f21ba-2115-4ba0-aca2-623500d7e3d9">|
|---|---|
| Broken link | Clicked `@tanstack/react-query with suspense` link |


## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
