### PR TITLE
feat(configs): add options for scripts

### DIFF
--- a/.changeset/breezy-colts-lick.md
+++ b/.changeset/breezy-colts-lick.md
@@ -1,0 +1,6 @@
+---
+"@suspensive/react-query": patch
+"@suspensive/react": patch
+---
+
+feat(configs): add options for scripts

--- a/configs/tsup/src/index.ts
+++ b/configs/tsup/src/index.ts
@@ -15,7 +15,7 @@ export const scriptOptions: Options = {
   clean: true,
   format: ['cjs'],
   target: ['chrome51', 'firefox53', 'edge18', 'safari11', 'ios11', 'opera38', 'es6', 'node14'],
-  entry: ['src/scripts/**/*.{ts,tsx}', '!**/*.{spec,test,test-d,bench}.*'],
+  entry: ['src/scripts/*.{ts,tsx}', '!**/*.{spec,test,test-d,bench}.*'],
   outDir: 'dist/scripts',
   sourcemap: true,
 }

--- a/configs/tsup/src/index.ts
+++ b/configs/tsup/src/index.ts
@@ -10,3 +10,12 @@ export const options: Options = {
   sourcemap: true,
   dts: true,
 }
+
+export const scriptOptions: Options = {
+  clean: true,
+  format: ['cjs'],
+  target: ['chrome51', 'firefox53', 'edge18', 'safari11', 'ios11', 'opera38', 'es6', 'node14'],
+  entry: ['src/scripts/**/*.{ts,tsx}', '!**/*.{spec,test,test-d,bench}.*'],
+  outDir: 'dist/scripts',
+  sourcemap: true,
+}

--- a/packages/react-query/tsup.config.ts
+++ b/packages/react-query/tsup.config.ts
@@ -1,15 +1,4 @@
-import { options } from '@suspensive/tsup'
+import { options, scriptOptions } from '@suspensive/tsup'
 import { defineConfig } from 'tsup'
 
-export default defineConfig([
-  options,
-  {
-    clean: true,
-    target: ['chrome51', 'firefox53', 'edge18', 'safari11', 'ios11', 'opera38', 'es6', 'node14'],
-    entry: ['src/scripts/*.{ts,tsx}', 'src/scripts/**/*.{ts,tsx}', '!**/*.{spec,test,test-d,bench}.*'],
-    outDir: 'dist/scripts',
-    format: ['cjs'],
-    sourcemap: true,
-    dts: true,
-  },
-])
+export default defineConfig([options, scriptOptions])


### PR DESCRIPTION
# Overview

- Since the current project uses `configs/tsup`, I have added the configuration for scripts.
- Currently, this script is only used in the react-query package, but there is potential to use this config in other packages in the future.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
