### PR TITLE
chore(suspensive.org): remove unnecessary theme property from _meta.json files

### DIFF
--- a/docs/suspensive.org/src/pages/_meta.en.json
+++ b/docs/suspensive.org/src/pages/_meta.en.json
@@ -19,9 +19,6 @@
   "versions": {
     "type": "menu",
     "title": "v2",
-    "theme": {
-      "collapsed": true
-    },
     "items": {
       "latest": {
         "title": "latest",

--- a/docs/suspensive.org/src/pages/_meta.ko.json
+++ b/docs/suspensive.org/src/pages/_meta.ko.json
@@ -19,9 +19,6 @@
   "versions": {
     "type": "menu",
     "title": "v2",
-    "theme": {
-      "collapsed": true
-    },
     "items": {
       "latest": {
         "title": "latest",


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->
In the development environment, error is occurring

<img width="767" alt="image" src="https://github.com/toss/suspensive/assets/23312485/aee3760d-67f8-4cdb-8306-33f76aaa1449">


When setting [`type: 'menu'` in Nextra](https://nextra.site/docs/docs-theme/page-configuration#menus), it is collapsed by default and it does not provide the themes property. so we remove it.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
