### PR TITLE
test(react-await): improve test coverage for `await.spec.tsx` (`unsubscribe` method)

### DIFF
--- a/packages/react-await/src/Await.spec.tsx
+++ b/packages/react-await/src/Await.spec.tsx
@@ -3,6 +3,7 @@ import { ERROR_MESSAGE, FALLBACK, TEXT, sleep } from '@suspensive/test-utils'
 import { render, screen, waitFor } from '@testing-library/react'
 import ms from 'ms'
 import { Await, awaitClient, useAwait } from '.'
+import { hashKey } from './utils'
 
 const key = (id: number) => ['key', id] as const
 
@@ -189,5 +190,13 @@ describe('awaitClient', () => {
     await waitFor(() => expect(screen.queryByText(TEXT)).toBeInTheDocument())
     expect(screen.queryByText(FALLBACK)).not.toBeInTheDocument()
     expect(awaitClient.getData(key(1))).toBe(TEXT)
+  })
+
+  it('should handle unsubscribe gracefully when no subscribers exist', () => {
+    const mockSync = vi.fn()
+    const key = ['nonexistent', 'key'] as const
+    awaitClient.unsubscribe(key, mockSync)
+
+    expect(awaitClient['syncsMap'].get(hashKey(key))).toBeUndefined()
   })
 })

--- a/packages/react-await/src/Await.spec.tsx
+++ b/packages/react-await/src/Await.spec.tsx
@@ -2,8 +2,8 @@ import { ErrorBoundary, Suspense } from '@suspensive/react'
 import { ERROR_MESSAGE, FALLBACK, TEXT, sleep } from '@suspensive/test-utils'
 import { render, screen, waitFor } from '@testing-library/react'
 import ms from 'ms'
-import { Await, awaitClient, useAwait } from '.'
 import { hashKey } from './utils'
+import { Await, awaitClient, useAwait } from '.'
 
 const key = (id: number) => ['key', id] as const
 


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

This PR improves the test coverage for `react-await`. In detail, it adds the test case for `unsubscribe` method in the `AwaitClient` class.  

#### AS-IS
<img width="528" alt="Captura de pantalla 2024-06-29 a las 2 43 22 p  m" src="https://github.com/toss/suspensive/assets/82362278/02955e73-21bf-4fb9-b5f6-e2ac98a0dd04">

#### TO-BE
<img width="523" alt="Captura de pantalla 2024-06-29 a las 2 43 42 p  m" src="https://github.com/toss/suspensive/assets/82362278/3273d2f4-8ae2-425c-b284-95fbe25eb422">


## PR Checklist

- [✅] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
