### PR TITLE
docs(suspensive.org): add sandpack examples to SuspenseQuery, SuspenseQueries, and SuspenseInfiniteQuery

### DIFF
--- a/docs/suspensive.org/src/pages/docs/react-query/SuspenseInfiniteQuery.en.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/SuspenseInfiniteQuery.en.mdx
@@ -1,3 +1,5 @@
+import { Sandpack } from '@/components'
+
 # SuspenseInfiniteQuery
 
 Just as [`<SuspenseQuery/>`](/docs/react-query/SuspenseQuery) makes useSuspenseQuery easier to use in jsx, `<SuspenseInfiniteQuery/>` serves to make useSuspenseInfiniteQuery easier to use in jsx.
@@ -5,16 +7,16 @@ Just as [`<SuspenseQuery/>`](/docs/react-query/SuspenseQuery) makes useSuspenseQ
 ```jsx /SuspenseInfiniteQuery/
 import { SuspenseInfiniteQuery } from '@suspensive/react-query'
 import { Suspense, ErrorBoundary } from '@suspensive/react'
-import { PostItem } from '~/components'
+import { PostListItem } from '~/components'
 
-const InfinitePostsPage = ({ authorId }) => (
+const InfinitePostsPage = ({ userId }) => (
   <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
     <Suspense fallback="loading...">
-      <SuspenseInfiniteQuery {...postsInfiniteQueryOptions(authorId)}>
+      <SuspenseInfiniteQuery {...postsInfiniteQueryOptions(userId)}>
         {({ data, fetchNextPage }) => (
           <>
             {data.pages.map((post) => (
-              <PostItem {...post} />
+              <PostListItem {...post} />
             ))}
             <button
               type="button"
@@ -22,7 +24,7 @@ const InfinitePostsPage = ({ authorId }) => (
                 fetchNextPage()
               }}
             >
-              more
+              Load More
             </button>
           </>
         )}
@@ -31,3 +33,108 @@ const InfinitePostsPage = ({ authorId }) => (
   </ErrorBoundary>
 )
 ```
+
+<Sandpack>
+
+```tsx Example.tsx active
+import React from 'react'
+import { SuspenseInfiniteQuery } from '@suspensive/react-query'
+import { Suspense, ErrorBoundary } from '@suspensive/react'
+import { PostListItem } from './PostListItem'
+import { postsInfiniteQueryOptions } from './queries'
+
+export const Example = () => {
+  return (
+    <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
+      <Suspense fallback={<div>Loading...</div>}>
+        <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '50px' }}>
+          <SuspenseInfiniteQuery
+            {...postsInfiniteQueryOptions()}
+            getNextPageParam={(lastPage, allPages) => {
+              return lastPage.skip + lastPage.limit < lastPage.total
+                ? allPages.length + 1
+                : undefined
+            }}
+          >
+            {({ data: { pages }, fetchNextPage, hasNextPage, isFetchingNextPage, isFetched }) => (
+              <>
+                <ol>
+                  {pages.map((page) =>
+                    page.data.map((post) => <PostListItem key={post.id} {...post} />)
+                  )}
+                </ol>
+                <button
+                  onClick={() => fetchNextPage()}
+                  disabled={!hasNextPage || isFetchingNextPage}
+                >
+                  {isFetchingNextPage
+                    ? 'Loading more...'
+                    : hasNextPage
+                    ? 'Load More'
+                    : 'Nothing more to load'}
+                </button>
+              </>
+            )}
+          </SuspenseInfiniteQuery>
+        </div>
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+```
+
+```tsx PostListItem.tsx
+
+```
+
+```tsx PostListItem.tsx
+import type { Post } from './api'
+
+export const PostListItem = (props: Post) => {
+  return (
+    <li style={{ marginBottom: '10px' }}>
+      {props.title}
+    </li>
+  )
+}
+```
+
+```tsx queries.ts
+import { queryOptions } from '@suspensive/react-query'
+import { getInfinitePosts } from './api'
+
+export const postsInfiniteQueryOptions = () =>
+  queryOptions({
+  queryKey: ['posts'],
+    queryFn: ({ pageParam = 1 }) => getInfinitePosts(pageParam),
+  })
+```
+
+```tsx api.ts
+type Post = {
+  userId: number
+  id: number
+  title: string
+  body: string
+}
+
+export const getInfinitePosts = async (page: number): Promise<{ data: Post[], page: number, total: number, limit: number, skip: number }> => {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/posts?_page=${page}&_limit=10`)
+
+  if (!response.ok) {
+    throw new Error('An error occurred')
+  }
+
+  const data = await response.json()
+
+  return {
+    data,
+    page,
+    total: 100,
+    limit: 10,
+    skip: (page - 1) * 10,
+  }
+}
+```
+
+</Sandpack>

--- a/docs/suspensive.org/src/pages/docs/react-query/SuspenseInfiniteQuery.ko.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/SuspenseInfiniteQuery.ko.mdx
@@ -1,3 +1,5 @@
+import { Sandpack } from '@/components'
+
 # SuspenseInfiniteQuery
 
 [`<SuspenseQuery/>`](/docs/react-query/SuspenseQuery)가 useSuspenseQuery를 jsx에서 쉽게 사용하게 하는 역할과 마찬가지로 `<SuspenseInfiniteQuery/>`는 useSuspenseInfiniteQuery를 jsx에서 사용하기 쉽게 하기 위한 역할을 합니다.
@@ -5,16 +7,16 @@
 ```jsx /SuspenseInfiniteQuery/
 import { SuspenseInfiniteQuery } from '@suspensive/react-query'
 import { Suspense, ErrorBoundary } from '@suspensive/react'
-import { PostItem } from '~/components'
+import { PostListItem } from '~/components'
 
-const InfinitePostsPage = ({ authorId }) => (
+const InfinitePostsPage = ({ userId }) => (
   <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
     <Suspense fallback="loading...">
-      <SuspenseInfiniteQuery {...postsInfiniteQueryOptions(authorId)}>
+      <SuspenseInfiniteQuery {...postsInfiniteQueryOptions(userId)}>
         {({ data, fetchNextPage }) => (
           <>
             {data.pages.map((post) => (
-              <PostItem {...post} />
+              <PostListItem {...post} />
             ))}
             <button
               type="button"
@@ -22,7 +24,7 @@ const InfinitePostsPage = ({ authorId }) => (
                 fetchNextPage()
               }}
             >
-              more
+              Load More
             </button>
           </>
         )}
@@ -31,3 +33,108 @@ const InfinitePostsPage = ({ authorId }) => (
   </ErrorBoundary>
 )
 ```
+
+<Sandpack>
+
+```tsx Example.tsx active
+import React from 'react'
+import { SuspenseInfiniteQuery } from '@suspensive/react-query'
+import { Suspense, ErrorBoundary } from '@suspensive/react'
+import { PostListItem } from './PostListItem'
+import { postsInfiniteQueryOptions } from './queries'
+
+export const Example = () => {
+  return (
+    <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
+      <Suspense fallback={<div>Loading...</div>}>
+        <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '50px' }}>
+          <SuspenseInfiniteQuery
+            {...postsInfiniteQueryOptions()}
+            getNextPageParam={(lastPage, allPages) => {
+              return lastPage.skip + lastPage.limit < lastPage.total
+                ? allPages.length + 1
+                : undefined
+            }}
+          >
+            {({ data: { pages }, fetchNextPage, hasNextPage, isFetchingNextPage, isFetched }) => (
+              <>
+                <ol>
+                  {pages.map((page) =>
+                    page.data.map((post) => <PostListItem key={post.id} {...post} />)
+                  )}
+                </ol>
+                <button
+                  onClick={() => fetchNextPage()}
+                  disabled={!hasNextPage || isFetchingNextPage}
+                >
+                  {isFetchingNextPage
+                    ? 'Loading more...'
+                    : hasNextPage
+                    ? 'Load More'
+                    : 'Nothing more to load'}
+                </button>
+              </>
+            )}
+          </SuspenseInfiniteQuery>
+        </div>
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+```
+
+```tsx PostListItem.tsx
+
+```
+
+```tsx PostListItem.tsx
+import type { Post } from './api'
+
+export const PostListItem = (props: Post) => {
+  return (
+    <li style={{ marginBottom: '10px' }}>
+      {props.title}
+    </li>
+  )
+}
+```
+
+```tsx queries.ts
+import { queryOptions } from '@suspensive/react-query'
+import { getInfinitePosts } from './api'
+
+export const postsInfiniteQueryOptions = () =>
+  queryOptions({
+  queryKey: ['posts'],
+    queryFn: ({ pageParam = 1 }) => getInfinitePosts(pageParam),
+  })
+```
+
+```tsx api.ts
+type Post = {
+  userId: number
+  id: number
+  title: string
+  body: string
+}
+
+export const getInfinitePosts = async (page: number): Promise<{ data: Post[], page: number, total: number, limit: number, skip: number }> => {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/posts?_page=${page}&_limit=10`)
+
+  if (!response.ok) {
+    throw new Error('An error occurred')
+  }
+
+  const data = await response.json()
+
+  return {
+    data,
+    page,
+    total: 100,
+    limit: 10,
+    skip: (page - 1) * 10,
+  }
+}
+```
+
+</Sandpack>

--- a/docs/suspensive.org/src/pages/docs/react-query/SuspenseQueries.en.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/SuspenseQueries.en.mdx
@@ -1,3 +1,5 @@
+import { Sandpack } from '@/components'
+
 # SuspenseQueries
 
 Just as [`<SuspenseQuery/>`](/docs/react-query/SuspenseQuery) makes useSuspenseQuery easier to use in jsx, `<SuspenseQueries/>` serves to make useSuspenseQueries easier to use in jsx.
@@ -5,15 +7,15 @@ Just as [`<SuspenseQuery/>`](/docs/react-query/SuspenseQuery) makes useSuspenseQ
 ```jsx /SuspenseQueries/
 import { SuspenseQueries } from '@suspensive/react-query'
 import { Suspense, ErrorBoundary } from '@suspensive/react'
-import { PostListItem, AuthorProfile } from '~/components'
+import { PostListItem, UserProfile } from '~/components'
 
-const PostsPage = ({ authorId }) => (
+const PostsPage = ({ userId }) => (
   <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
     <Suspense fallback="loading...">
-      <SuspenseQueries queries={[userQueryOptions(authorId), postsQueryOptions(authorId)]}>
-        {([{ data: author }, { data: posts }]) => (
+      <SuspenseQueries queries={[userQueryOptions(userId), postsQueryOptions(userId)]}>
+        {([{ data: user }, { data: posts }]) => (
           <>
-            {<AuthorProfile {...author} />}
+            {<UserProfile {...user} />}
             {posts.map((post) => (
               <PostListItem key={post.id} {...post} />
             ))}
@@ -24,3 +26,145 @@ const PostsPage = ({ authorId }) => (
   </ErrorBoundary>
 )
 ```
+
+<Sandpack>
+
+```tsx Example.tsx active
+import React from 'react'
+import { SuspenseQueries } from '@suspensive/react-query'
+import { Suspense, ErrorBoundary } from '@suspensive/react'
+import { PostListItem } from './PostListItem'
+import { UserProfile } from './UserProfile'
+import { userQueryOptions, postsQueryOptions } from './queries'
+
+export const Example = () => {
+  const [userId, setUserId] = React.useState(1)
+
+  return (
+    <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
+      <button onClick={() => setUserId((id) => id - 1)} disabled={userId === 1}>
+        Previous User
+      </button>
+      <button onClick={() => setUserId((id) => id + 1)} disabled={userId === 10}>
+        Next User
+      </button>
+      <Suspense fallback={<div>Loading...</div>}>
+        <SuspenseQueries queries={[userQueryOptions(userId), postsQueryOptions(userId)]}>
+          {([{ data: user }, { data: posts }]) => (
+            <>
+              <UserProfile {...user} />
+              <ol>
+                {posts.map((post) => (
+                  <PostListItem key={post.id} {...post} />
+                ))}
+              </ol>
+            </>
+          )}
+        </SuspenseQueries>
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+```
+
+```tsx PostListItem.tsx
+import type { Post } from './api'
+
+export const PostListItem = (props: Post) => {
+  return (
+    <li style={{ marginBottom: '10px' }}>
+      {props.title}
+    </li>
+  )
+}
+```
+
+```tsx UserProfile.tsx
+import type { User } from './api'
+
+export const UserProfile = (props: User) => {
+  return (
+    <div style={{ padding: '16px' }}>
+      <h1>{props.name}</h1>
+      <p>{props.email}</p>
+      <p>{props.phone}</p>
+    </div>
+  )
+}
+```
+
+```tsx queries.ts
+import { queryOptions } from '@suspensive/react-query'
+import { getPosts, getUser } from './api'
+
+export const userQueryOptions = (userId: number) =>
+  queryOptions({
+    queryKey: ['users', userId],
+    queryFn: () => getUser(userId),
+  })
+
+export const postsQueryOptions = (userId: number) =>
+  queryOptions({
+    queryKey: ['users', userId, 'posts'],
+    queryFn: () => getPosts(userId),
+  })
+```
+
+```tsx api.ts
+export type Post = {
+  userId: number
+  id: number
+  title: string
+  body: string
+}
+
+export const getPosts = async (userId: number): Promise<Post[]> => {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/posts?userId=${userId}`)
+
+  if (!response.ok) {
+    throw new Error('An error occurred')
+  }
+
+  const data = await response.json()
+
+  return data
+}
+
+export type User = {
+  id: number
+  name: string
+  username: string
+  email: string
+  address: {
+    street: string
+    suite: string
+    city: string
+    zipcode: string
+    geo: {
+      lat: string
+      lng: string
+    }
+    phone: string
+    website: string
+    company: {
+      name: string
+      catchPhrase: string
+      bs: string
+    }
+  }
+}
+
+export const getUser = async (id: number): Promise<User> => {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/users/${id}`)
+
+  if (!response.ok) {
+    throw new Error('An error occurred')
+  }
+
+  const data = await response.json()
+
+  return data
+}
+```
+
+</Sandpack>

--- a/docs/suspensive.org/src/pages/docs/react-query/SuspenseQueries.ko.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/SuspenseQueries.ko.mdx
@@ -1,3 +1,5 @@
+import { Sandpack } from '@/components'
+
 # SuspenseQueries
 
 [`<SuspenseQuery/>`](/docs/react-query/SuspenseQuery)가 useSuspenseQuery를 jsx에서 쉽게 사용하게 하는 역할과 마찬가지로 `<SuspenseQueries/>`는 useSuspenseQueries를 jsx에서 사용하기 쉽게 하기 위한 역할을 합니다.
@@ -5,15 +7,15 @@
 ```jsx /SuspenseQueries/
 import { SuspenseQueries } from '@suspensive/react-query'
 import { Suspense, ErrorBoundary } from '@suspensive/react'
-import { PostListItem, AuthorProfile } from '~/components'
+import { PostListItem, UserProfile } from '~/components'
 
-const PostsPage = ({ authorId }) => (
+const PostsPage = ({ userId }) => (
   <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
     <Suspense fallback="loading...">
-      <SuspenseQueries queries={[userQueryOptions(authorId), postsQueryOptions(authorId)]}>
-        {([{ data: author }, { data: posts }]) => (
+      <SuspenseQueries queries={[userQueryOptions(userId), postsQueryOptions(userId)]}>
+        {([{ data: user }, { data: posts }]) => (
           <>
-            {<AuthorProfile {...author} />}
+            <UserProfile {...user} />
             {posts.map((post) => (
               <PostListItem key={post.id} {...post} />
             ))}
@@ -24,3 +26,145 @@ const PostsPage = ({ authorId }) => (
   </ErrorBoundary>
 )
 ```
+
+<Sandpack>
+
+```tsx Example.tsx active
+import React from 'react'
+import { SuspenseQueries } from '@suspensive/react-query'
+import { Suspense, ErrorBoundary } from '@suspensive/react'
+import { PostListItem } from './PostListItem'
+import { UserProfile } from './UserProfile'
+import { userQueryOptions, postsQueryOptions } from './queries'
+
+export const Example = () => {
+  const [userId, setUserId] = React.useState(1)
+
+  return (
+    <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
+      <button onClick={() => setUserId((id) => id - 1)} disabled={userId === 1}>
+        Previous User
+      </button>
+      <button onClick={() => setUserId((id) => id + 1)} disabled={userId === 10}>
+        Next User
+      </button>
+      <Suspense fallback={<div>Loading...</div>}>
+        <SuspenseQueries queries={[userQueryOptions(userId), postsQueryOptions(userId)]}>
+          {([{ data: user }, { data: posts }]) => (
+            <>
+              <UserProfile {...user} />
+              <ol>
+                {posts.map((post) => (
+                  <PostListItem key={post.id} {...post} />
+                ))}
+              </ol>
+            </>
+          )}
+        </SuspenseQueries>
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+```
+
+```tsx PostListItem.tsx
+import type { Post } from './api'
+
+export const PostListItem = (props: Post) => {
+  return (
+    <li style={{ marginBottom: '10px' }}>
+      {props.title}
+    </li>
+  )
+}
+```
+
+```tsx UserProfile.tsx
+import type { User } from './api'
+
+export const UserProfile = (props: User) => {
+  return (
+    <div style={{ padding: '16px' }}>
+      <h1>{props.name}</h1>
+      <p>{props.email}</p>
+      <p>{props.phone}</p>
+    </div>
+  )
+}
+```
+
+```tsx queries.ts
+import { queryOptions } from '@suspensive/react-query'
+import { getPosts, getUser } from './api'
+
+export const userQueryOptions = (userId: number) =>
+  queryOptions({
+    queryKey: ['users', userId],
+    queryFn: () => getUser(userId),
+  })
+
+export const postsQueryOptions = (userId: number) =>
+  queryOptions({
+    queryKey: ['users', userId, 'posts'],
+    queryFn: () => getPosts(userId),
+  })
+```
+
+```tsx api.ts
+export type Post = {
+  userId: number
+  id: number
+  title: string
+  body: string
+}
+
+export const getPosts = async (userId: number): Promise<Post[]> => {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/posts?userId=${userId}`)
+
+  if (!response.ok) {
+    throw new Error('An error occurred')
+  }
+
+  const data = await response.json()
+
+  return data
+}
+
+export type User = {
+  id: number
+  name: string
+  username: string
+  email: string
+  address: {
+    street: string
+    suite: string
+    city: string
+    zipcode: string
+    geo: {
+      lat: string
+      lng: string
+    }
+    phone: string
+    website: string
+    company: {
+      name: string
+      catchPhrase: string
+      bs: string
+    }
+  }
+}
+
+export const getUser = async (id: number): Promise<User> => {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/users/${id}`)
+
+  if (!response.ok) {
+    throw new Error('An error occurred')
+  }
+
+  const data = await response.json()
+
+  return data
+}
+```
+
+</Sandpack>

--- a/docs/suspensive.org/src/pages/docs/react-query/SuspenseQuery.en.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/SuspenseQuery.en.mdx
@@ -1,45 +1,207 @@
+import { Sandpack } from '@/components'
+
 # SuspenseQuery
 
 We provide these components to clearly express what causes suspense at the same depth.
 
-1. Prop-drilling resulting from removing depth such as AuthorInfo and PostList for data-fetching only is also removed.
+1. Prop-drilling resulting from removing depth such as UserInfo and PostList for data-fetching only is also removed.
 2. Changing the range of Suspense and ErrorBoundary becomes simple. Parallel processing of queries is also easier.
 3. Because it manages all data-fetching within the Page component, the internal components are presentational, so it is easy to separate the components.
 
 ```jsx /SuspenseQuery/
 import { SuspenseQuery } from '@suspensive/react-query'
 import { Suspense, ErrorBoundary } from '@suspensive/react'
-import { PostListItem, AuthorProfile } from '~/components'
+import { PostListItem, UserProfile } from '~/components'
 
-const PostsPage = ({ authorId }) => (
+const PostsPage = ({ userId }) => (
   <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
     <Suspense fallback={'loading...'}>
-      <SuspenseQuery {...userQueryOptions(authorId)}>
-        {({ data: author }) => <AuthorProfile {...author} />}
+      <SuspenseQuery {...userQueryOptions(userId)}>
+        {({ data: user }) => <UserProfile key={user.id} {...user} />}
       </SuspenseQuery>
-      <SuspenseQuery {...postsQueryOptions(authorId)} select={(posts) => posts.filter(({ isShow }) => isShow)}>
-        {({ data: posts }) => posts.map((post) => <PostListItem {...post} />)}
+      <SuspenseQuery {...postsQueryOptions(userId)} select={(posts) => posts.filter(({ isPublic }) => isPublic)}>
+        {({ data: posts }) => posts.map((post) => <PostListItem key={post.id} {...post} />)}
       </SuspenseQuery>
     </Suspense>
   </ErrorBoundary>
 )
 ```
 
+<Sandpack>
+
+```tsx Example.tsx active
+import React from 'react'
+import { ErrorBoundary, Suspense } from '@suspensive/react'
+import { SuspenseQuery } from '@suspensive/react-query'
+import { PostListItem } from './PostListItem'
+import { UserProfile } from './UserProfile'
+import { postsQueryOptions, userQueryOptions } from './queries'
+
+export const Example = () => {
+  const [userId, setUserId] = React.useState(1)
+  const [showAllPosts, setShowAllPosts] = React.useState(false)
+
+  return (
+    <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
+      <button onClick={() => setUserId((id) => id - 1)} disabled={userId === 1}>
+        Previous User
+      </button>
+      <button onClick={() => setUserId((id) => id + 1)} disabled={userId === 10}>
+        Next User
+      </button>
+      <Suspense fallback={<div>Loading...</div>}>
+        <SuspenseQuery {...userQueryOptions(userId)}>
+          {({ data: user }) => <UserProfile key={user.id} {...user} />}
+        </SuspenseQuery>
+
+        <label>
+          <input
+            type="checkbox"
+            checked={showAllPosts}
+            onChange={() => setShowAllPosts((showAllPosts) => !showAllPosts)}
+          />
+          Show All Posts
+        </label>
+
+        <SuspenseQuery
+          {...postsQueryOptions(userId)}
+          select={(posts) => posts.filter(({ isPublic }) => showAllPosts || isPublic)}
+        >
+          {({ data: posts }) => (
+            <ol>
+              {posts.map((post) => (
+                <PostListItem key={post.id} {...post} />
+              ))}
+            </ol>
+          )}
+        </SuspenseQuery>
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+```
+
+```tsx PostListItem.tsx
+import type { Post } from './api'
+
+export const PostListItem = (props: Post) => {
+  return (
+    <li style={{ marginBottom: '10px' }}>
+      <span style={{ color: props.isPublic ? 'green' : 'red' }}>{props.isPublic ? 'Public' : 'Private'} Post</span> {props.title}
+    </li>
+  )
+}
+```
+
+```tsx UserProfile.tsx
+import type { User } from './api'
+
+export const UserProfile = (props: User) => {
+  return (
+    <div style={{ padding: '16px' }}>
+      <h1>{props.name}</h1>
+      <p>{props.email}</p>
+      <p>{props.phone}</p>
+    </div>
+  )
+}
+```
+
+```tsx queries.ts
+import { queryOptions } from '@suspensive/react-query'
+import { getPosts, getUser } from './api'
+
+export const userQueryOptions = (userId: number) =>
+  queryOptions({
+    queryKey: ['users', userId],
+    queryFn: () => getUser(userId),
+  })
+
+export const postsQueryOptions = (userId: number) =>
+  queryOptions({
+    queryKey: ['users', userId, 'posts'],
+    queryFn: () => getPosts(userId),
+  })
+```
+
+```tsx api.ts
+export type Post = {
+  userId: number
+  id: number
+  title: string
+  body: string
+  isPublic: boolean
+}
+
+export const getPosts = async (userId: number): Promise<Post[]> => {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/posts?userId=${userId}`)
+
+  if (!response.ok) {
+    throw new Error('An error occurred')
+  }
+
+  const data = await response.json()
+
+  return data.map((post, index) => ({
+    ...post,
+    isPublic: index % 2 === 1,
+  }))
+}
+
+export type User = {
+  id: number
+  name: string
+  username: string
+  email: string
+  address: {
+    street: string
+    suite: string
+    city: string
+    zipcode: string
+    geo: {
+      lat: string
+      lng: string
+    }
+    phone: string
+    website: string
+    company: {
+      name: string
+      catchPhrase: string
+      bs: string
+    }
+  }
+}
+
+export const getUser = async (id: number): Promise<User> => {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/users/${id}`)
+
+  if (!response.ok) {
+    throw new Error('An error occurred')
+  }
+
+  const data = await response.json()
+
+  return data
+}
+```
+
+</Sandpack>
+
 ## Motivation: useSuspenseQuery is not obvious
 
-Because the existing useSuspenseQuery is a hook, it creates components with names such as AuthorInfo and PostList to place Suspense and ErrorBoundary on the parent.
-This makes it difficult to predict what suspense and errors will be thrown inside AuthorInfo and PostList.
+Because the existing useSuspenseQuery is a hook, it creates components with names such as UserInfo and PostList to place Suspense and ErrorBoundary on the parent.
+This makes it difficult to predict what suspense and errors will be thrown inside UserInfo and PostList.
 
 ```jsx
 // posts/page.tsx
 import { Suspense, ErrorBoundary } from '@suspensive/react'
-import { AuthorInfo } from './components/AuthorInfo'
+import { UserInfo } from './components/UserInfo'
 import { PostList } from './components/PostList'
 
 const PostsPage = ({ userId }) => (
   <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
     <Suspense fallback={'loading...'}>
-      <AuthorInfo userId={userId} /> {/* It is difficult to predict whether a suspension will occur internally. */}
+      <UserInfo userId={userId} /> {/* It is difficult to predict whether a suspension will occur internally. */}
       <PostList userId={userId} /> {/* It is difficult to predict whether a suspension will occur internally. */}
     </Suspense>
   </ErrorBoundary>
@@ -47,16 +209,16 @@ const PostsPage = ({ userId }) => (
 ```
 
 ```jsx /useSuspenseQuery/
-// posts/components/AuthorInfo.tsx
+// posts/components/UserInfo.tsx
 import { useSuspenseQuery } from '@suspensive/react-query'
-import { AuthorProfile } from '~/components'
+import { UserProfile } from '~/components'
 
-// From the perspective of using this component, it is impossible to predict whether Suspense will occur internally just by the name AuthorInfo.
-const AuthorInfo = ({ userId }) => {
+// From the perspective of using this component, it is impossible to predict whether Suspense will occur internally just by the name UserInfo.
+const UserInfo = ({ userId }) => {
   // We need to create this component just for data-fetching.
-  const { data: author } = useSuspenseQuery(userQueryOptions(userId))
+  const { data: user } = useSuspenseQuery(userQueryOptions(userId))
 
-  return <AuthorProfile {...author} />
+  return <UserProfile {...user} />
 }
 ```
 
@@ -70,7 +232,7 @@ const PostList = ({ userId }) => {
    // We need to create this component just for data-fetching.
    const { data: posts } = useSuspenseQuery({
      ...postsQueryOptions(userId);
-     select: (posts) => posts.filter(({ isShow }) => isShow),
+     select: (posts) => posts.filter(({ isPublic }) => isPublic),
    })
 
    return (

--- a/docs/suspensive.org/src/pages/docs/react-query/SuspenseQuery.ko.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/SuspenseQuery.ko.mdx
@@ -1,45 +1,207 @@
+import { Sandpack } from '@/components'
+
 # SuspenseQuery
 
 같은 depth에서 Suspense를 발생시키는 것이 무엇인지 명확하게 표현하기 위해 이 컴포넌트들을 제공합니다.
 
-1. data-fetching만을 위한 AuthorInfo, PostList와 같은 depth를 제거하기 때문에 생긴 prop-drilling도 제거됩니다.
+1. data-fetching만을 위한 UserInfo, PostList와 같은 depth를 제거하기 때문에 생긴 prop-drilling도 제거됩니다.
 2. Suspense, ErrorBoundary의 범위 변경도 간단해집니다. query의 병렬처리도 더 쉽습니다.
 3. Page 컴포넌트 내에서 data-fetching을 모두 관장하기 때문에 내부의 컴포넌트는 presentational하므로 컴포넌트를 분리하기 쉽습니다.
 
 ```jsx /SuspenseQuery/
 import { SuspenseQuery } from '@suspensive/react-query'
 import { Suspense, ErrorBoundary } from '@suspensive/react'
-import { PostListItem, AuthorProfile } from '~/components'
+import { PostListItem, UserProfile } from '~/components'
 
-const PostsPage = ({ authorId }) => (
+const PostsPage = ({ userId }) => (
   <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
     <Suspense fallback={'loading...'}>
-      <SuspenseQuery {...userQueryOptions(authorId)}>
-        {({ data: author }) => <AuthorProfile {...author} />}
+      <SuspenseQuery {...userQueryOptions(userId)}>
+        {({ data: user }) => <UserProfile key={user.id} {...user} />}
       </SuspenseQuery>
-      <SuspenseQuery {...postsQueryOptions(authorId)} select={(posts) => posts.filter(({ isShow }) => isShow)}>
-        {({ data: posts }) => posts.map((post) => <PostListItem {...post} />)}
+      <SuspenseQuery {...postsQueryOptions(userId)} select={(posts) => posts.filter(({ isPublic }) => isPublic)}>
+        {({ data: posts }) => posts.map((post) => <PostListItem key={post.id} {...post} />)}
       </SuspenseQuery>
     </Suspense>
   </ErrorBoundary>
 )
 ```
 
+<Sandpack>
+
+```tsx Example.tsx active
+import React from 'react'
+import { ErrorBoundary, Suspense } from '@suspensive/react'
+import { SuspenseQuery } from '@suspensive/react-query'
+import { PostListItem } from './PostListItem'
+import { UserProfile } from './UserProfile'
+import { postsQueryOptions, userQueryOptions } from './queries'
+
+export const Example = () => {
+  const [userId, setUserId] = React.useState(1)
+  const [showAllPosts, setShowAllPosts] = React.useState(false)
+
+  return (
+    <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
+      <button onClick={() => setUserId((id) => id - 1)} disabled={userId === 1}>
+        Previous User
+      </button>
+      <button onClick={() => setUserId((id) => id + 1)} disabled={userId === 10}>
+        Next User
+      </button>
+      <Suspense fallback={<div>Loading...</div>}>
+        <SuspenseQuery {...userQueryOptions(userId)}>
+          {({ data: user }) => <UserProfile key={user.id} {...user} />}
+        </SuspenseQuery>
+
+        <label>
+          <input
+            type="checkbox"
+            checked={showAllPosts}
+            onChange={() => setShowAllPosts((showAllPosts) => !showAllPosts)}
+          />
+          Show All Posts
+        </label>
+
+        <SuspenseQuery
+          {...postsQueryOptions(userId)}
+          select={(posts) => posts.filter(({ isPublic }) => showAllPosts || isPublic)}
+        >
+          {({ data: posts }) => (
+            <ol>
+              {posts.map((post) => (
+                <PostListItem key={post.id} {...post} />
+              ))}
+            </ol>
+          )}
+        </SuspenseQuery>
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+```
+
+```tsx PostListItem.tsx
+import type { Post } from './api'
+
+export const PostListItem = (props: Post) => {
+  return (
+    <li style={{ marginBottom: '10px' }}>
+      <span style={{ color: props.isPublic ? 'green' : 'red' }}>{props.isPublic ? 'Public' : 'Private'} Post</span> {props.title}
+    </li>
+  )
+}
+```
+
+```tsx UserProfile.tsx
+import type { User } from './api'
+
+export const UserProfile = (props: User) => {
+  return (
+    <div style={{ padding: '16px' }}>
+      <h1>{props.name}</h1>
+      <p>{props.email}</p>
+      <p>{props.phone}</p>
+    </div>
+  )
+}
+```
+
+```tsx queries.ts
+import { queryOptions } from '@suspensive/react-query'
+import { getPosts, getUser } from './api'
+
+export const userQueryOptions = (userId: number) =>
+  queryOptions({
+    queryKey: ['users', userId],
+    queryFn: () => getUser(userId),
+  })
+
+export const postsQueryOptions = (userId: number) =>
+  queryOptions({
+    queryKey: ['users', userId, 'posts'],
+    queryFn: () => getPosts(userId),
+  })
+```
+
+```tsx api.ts
+export type Post = {
+  userId: number
+  id: number
+  title: string
+  body: string
+  isPublic: boolean
+}
+
+export const getPosts = async (userId: number): Promise<Post[]> => {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/posts?userId=${userId}`)
+
+  if (!response.ok) {
+    throw new Error('An error occurred')
+  }
+
+  const data = await response.json()
+
+  return data.map((post, index) => ({
+    ...post,
+    isPublic: index % 2 === 1,
+  }))
+}
+
+export type User = {
+  id: number
+  name: string
+  username: string
+  email: string
+  address: {
+    street: string
+    suite: string
+    city: string
+    zipcode: string
+    geo: {
+      lat: string
+      lng: string
+    }
+    phone: string
+    website: string
+    company: {
+      name: string
+      catchPhrase: string
+      bs: string
+    }
+  }
+}
+
+export const getUser = async (id: number): Promise<User> => {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/users/${id}`)
+
+  if (!response.ok) {
+    throw new Error('An error occurred')
+  }
+
+  const data = await response.json()
+
+  return data
+}
+```
+
+</Sandpack>
+
 ## 동기: useSuspenseQuery가 명확히 드러나지 않음
 
-기존의 useSuspenseQuery는 훅이기 때문에 부모에 Suspense, ErrorBoundary를 배치하기 위해 AuthorInfo, PostList와 같은 이름을 가진 컴포넌트를 만들게 합니다.
-이것은 AuthorInfo, PostList 내부에서 던져질 suspense와 error가 있을지 예측하기 어렵게 만듭니다.
+기존의 useSuspenseQuery는 훅이기 때문에 부모에 Suspense, ErrorBoundary를 배치하기 위해 UserInfo, PostList와 같은 이름을 가진 컴포넌트를 만들게 합니다.
+이것은 UserInfo, PostList 내부에서 던져질 suspense와 error가 있을지 예측하기 어렵게 만듭니다.
 
 ```jsx /useSuspenseQuery/
 // posts/page.tsx
 import { Suspense, ErrorBoundary } from '@suspensive/react'
-import { AuthorInfo } from './components/AuthorInfo'
+import { UserInfo } from './components/UserInfo'
 import { PostList } from './components/PostList'
 
 const PostsPage = ({ userId }) => (
   <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
     <Suspense fallback={'loading...'}>
-      <AuthorInfo userId={userId} /> {/* 내부적으로 Suspense를 발생할 지 예상하기 어렵습니다. */}
+      <UserInfo userId={userId} /> {/* 내부적으로 Suspense를 발생할 지 예상하기 어렵습니다. */}
       <PostList userId={userId} /> {/* 내부적으로 Suspense를 발생할 지 예상하기 어렵습니다. */}
     </Suspense>
   </ErrorBoundary>
@@ -47,16 +209,16 @@ const PostsPage = ({ userId }) => (
 ```
 
 ```jsx /useSuspenseQuery/
-// posts/components/AuthorInfo.tsx
+// posts/components/UserInfo.tsx
 import { useSuspenseQuery } from '@suspensive/react-query'
-import { AuthorProfile } from '~/components'
+import { UserProfile } from '~/components'
 
-// 이 컴포넌트를 사용하는 입장에서는 AuthorInfo라는 이름만으로는 내부적으로 Suspense를 발생시키는 지 예측할 수 없습니다.
-const AuthorInfo = ({ userId }) => {
+// 이 컴포넌트를 사용하는 입장에서는 UserInfo라는 이름만으로는 내부적으로 Suspense를 발생시키는 지 예측할 수 없습니다.
+const UserInfo = ({ userId }) => {
   // data-fetching만을 위한 이 컴포넌트를 만들어야 합니다.
-  const { data: author } = useSuspenseQuery(userQueryOptions(userId))
+  const { data: user } = useSuspenseQuery(userQueryOptions(userId))
 
-  return <AuthorProfile {...author} />
+  return <UserProfile {...user} />
 }
 ```
 
@@ -70,7 +232,7 @@ const PostList = ({ userId }) => {
   // data-fetching만을 위한 이 컴포넌트를 만들어야 합니다.
   const { data: posts } = useSuspenseQuery({
     ...postsQueryOptions(userId),
-    select: (posts) => posts.filter(({ isShow }) => isShow),
+    select: (posts) => posts.filter(({ isPublic }) => isPublic),
   })
 
   return (

--- a/docs/suspensive.org/src/pages/docs/react-query/useSuspenseInfiniteQuery.en.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/useSuspenseInfiniteQuery.en.mdx
@@ -91,7 +91,7 @@ type Post = {
 }
 
 export const getPosts = async (page: number): Promise<{ data: Post[], page: number, total: number, limit: number, skip: number }> => {
-  const response = await fetch(`https://jsonplaceholder.typicode.com/posts?_page=${page}`)
+  const response = await fetch(`https://jsonplaceholder.typicode.com/posts?_page=${page}&_limit=10`)
 
   if (!response.ok) {
     throw new Error('An error occurred')

--- a/docs/suspensive.org/src/pages/docs/react-query/useSuspenseInfiniteQuery.ko.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/useSuspenseInfiniteQuery.ko.mdx
@@ -91,7 +91,7 @@ type Post = {
 }
 
 export const getPosts = async (page: number): Promise<{ data: Post[], page: number, total: number, limit: number, skip: number }> => {
-  const response = await fetch(`https://jsonplaceholder.typicode.com/posts?_page=${page}`)
+  const response = await fetch(`https://jsonplaceholder.typicode.com/posts?_page=${page}&_limit=10`)
 
   if (!response.ok) {
     throw new Error('An error occurred')


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Add sandpack examples to SuspenseQuery, SuspenseQueries, and SuspenseInfiniteQuery.

I found a type error that occurs when passing the return value of queryOptions as a property to SuspenseInfiniteQuery. Since Sandpack doesn't catch type errors, I'm submitting this PR while creating a separate issue for the type problem. (Issue: https://github.com/toss/suspensive/issues/1015)

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
