### PR TITLE
fix(react-query): remove experimental in jsdoc

### DIFF
--- a/.changeset/lazy-coins-appear.md
+++ b/.changeset/lazy-coins-appear.md
@@ -1,0 +1,7 @@
+---
+"@suspensive/react-query-4": patch
+"@suspensive/react-query-5": patch
+"@suspensive/react-query": patch
+---
+
+fix(react-query): remove experimental in jsdoc

--- a/docs/suspensive.org/src/pages/docs/react-query/tanstack-query-compatibility.en.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/tanstack-query-compatibility.en.mdx
@@ -12,8 +12,6 @@ The Command-Line Interface (CLI) of @suspensive/react-query is a tool designed t
 
 If an error occurs due to incompatibility with @tanstack/react-query for any special reason, the CLI can be used to resolve the issue. However, the actual use of the CLI is rare, as the appropriate interface is automatically used upon installing @suspensive/react-query.
 
-<Callout type="info">The CLI is still experimental and may not function as intended.</Callout>
-
 ## Getting Started
 
 The CLI is included in the @suspensive/react-query package. No additional installation is needed, and it can be used immediately with the following command.

--- a/docs/suspensive.org/src/pages/docs/react-query/tanstack-query-compatibility.ko.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/tanstack-query-compatibility.ko.mdx
@@ -12,8 +12,6 @@ import { Callout } from '@/components'
 
 특수한 이유로 @tanstack/react-query와 호환되지 않아 에러가 발생하면, CLI를 통해 문제를 해결할 수 있습니다. 하지만 실제로 CLI를 사용할 일은 드물며, @suspensive/react-query 설치 시 자동으로 알맞은 인터페이스를 사용합니다.
 
-<Callout type="info">CLI는 아직 실험적인 기능이며, 의도대로 동작하지 않을 수 있습니다.</Callout>
-
 ## 시작하기
 
 CLI는 @suspensive/react-query 패키지에 포함되어 있습니다. 추가적인 설치는 필요 없으며, 아래 명령어를 통해 바로 사용할 수 있습니다.

--- a/docs/suspensive.org/src/pages/docs/react/Delay.ko.mdx
+++ b/docs/suspensive.org/src/pages/docs/react/Delay.ko.mdx
@@ -48,12 +48,6 @@ Default ms
 
 ### props.fallback
 
-<Callout type='warning'>
-
-`<Delay/>`의 fallback는 실험 기능이므로 이 인터페이스는 변경될 수 있습니다
-
-</Callout>
-
 delay된 children 노출 전까지 보여줄 수 있는 fallback입니다
 
 ```jsx /fallback/

--- a/packages/react-query-4/src/SuspenseInfiniteQuery.tsx
+++ b/packages/react-query-4/src/SuspenseInfiniteQuery.tsx
@@ -6,9 +6,6 @@ import {
   useSuspenseInfiniteQuery,
 } from './useSuspenseInfiniteQuery'
 
-/**
- * @experimental This is experimental feature.
- */
 export const SuspenseInfiniteQuery = <
   TQueryFnData = unknown,
   TError = unknown,

--- a/packages/react-query-4/src/SuspenseQueries.tsx
+++ b/packages/react-query-4/src/SuspenseQueries.tsx
@@ -1,9 +1,6 @@
 import type { ReactNode } from 'react'
 import { type SuspenseQueriesOptions, type SuspenseQueriesResults, useSuspenseQueries } from './useSuspenseQueries'
 
-/**
- * @experimental This is experimental feature.
- */
 export function SuspenseQueries<T extends any[]>({
   children,
   queries,

--- a/packages/react-query-4/src/SuspenseQuery.tsx
+++ b/packages/react-query-4/src/SuspenseQuery.tsx
@@ -2,9 +2,6 @@ import type { QueryKey } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { type UseSuspenseQueryOptions, type UseSuspenseQueryResult, useSuspenseQuery } from './useSuspenseQuery'
 
-/**
- * @experimental This is experimental feature.
- */
 export const SuspenseQuery = <
   TQueryFnData = unknown,
   TError = unknown,

--- a/packages/react-query-4/src/queryOptions.ts
+++ b/packages/react-query-4/src/queryOptions.ts
@@ -71,9 +71,6 @@ export function queryOptions<
 >(
   options: UnSelectedQueryOptions<TQueryFnData, TError, TData, TQueryKey>
 ): UnSelectedQueryOptions<TQueryFnData, TError, TData, TQueryKey>
-/**
- * @experimental This is experimental feature.
- */
 export function queryOptions<
   TQueryFnData = unknown,
   TError = unknown,

--- a/packages/react-query-5/src/QueryErrorBoundary.tsx
+++ b/packages/react-query-5/src/QueryErrorBoundary.tsx
@@ -2,9 +2,6 @@ import { ErrorBoundary } from '@suspensive/react'
 import { useQueryErrorResetBoundary } from '@tanstack/react-query'
 import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef } from 'react'
 
-/**
- * @experimental This is experimental feature.
- */
 export const QueryErrorBoundary = forwardRef<
   ComponentRef<typeof ErrorBoundary>,
   ComponentPropsWithoutRef<typeof ErrorBoundary>

--- a/packages/react-query-5/src/SuspenseInfiniteQuery.tsx
+++ b/packages/react-query-5/src/SuspenseInfiniteQuery.tsx
@@ -8,9 +8,6 @@ import {
 } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 
-/**
- * @experimental This is experimental feature.
- */
 export const SuspenseInfiniteQuery = <
   TQueryFnData,
   TError = DefaultError,

--- a/packages/react-query-5/src/SuspenseQueries.tsx
+++ b/packages/react-query-5/src/SuspenseQueries.tsx
@@ -1,9 +1,6 @@
 import { type SuspenseQueriesOptions, type SuspenseQueriesResults, useSuspenseQueries } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 
-/**
- * @experimental This is experimental feature.
- */
 export function SuspenseQueries<T extends any[], TCombinedResult = SuspenseQueriesResults<T>>({
   children,
   queries,

--- a/packages/react-query-5/src/SuspenseQuery.tsx
+++ b/packages/react-query-5/src/SuspenseQuery.tsx
@@ -7,9 +7,6 @@ import {
 } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 
-/**
- * @experimental This is experimental feature.
- */
 export const SuspenseQuery = <
   TQueryFnData = unknown,
   TError = DefaultError,

--- a/packages/react-query/src/scripts/utils/commands.spec.ts
+++ b/packages/react-query/src/scripts/utils/commands.spec.ts
@@ -64,7 +64,6 @@ describe('commands', () => {
 
       statusAction()
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(`"suspensive-react-query status" is experimental feature`)
       expect(consoleLogSpy).toHaveBeenCalledWith('\nSuspensive React Query status:')
       expect(consoleLogSpy).toHaveBeenCalledWith(
         `@suspensive/react-query@${packageJson.version} export @suspensive/react-query-4's interfaces`
@@ -83,7 +82,6 @@ describe('commands', () => {
 
       statusAction()
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(`"suspensive-react-query status" is experimental feature`)
       expect(consoleLogSpy).toHaveBeenCalledWith('\nSuspensive React Query status:')
       expect(consoleLogSpy).toHaveBeenCalledWith(
         `@suspensive/react-query@${packageJson.version} export @suspensive/react-query-5's interfaces`
@@ -122,14 +120,12 @@ describe('commands', () => {
     it('should switch to version 4', () => {
       switchAction('4')
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(`"suspensive-react-query switch <version>" is experimental feature`)
       expect(switchVersion).toHaveBeenCalledWith(4)
     })
 
     it('should switch to version 5', () => {
       switchAction('5')
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(`"suspensive-react-query switch <version>" is experimental feature`)
       expect(switchVersion).toHaveBeenCalledWith(5)
     })
 
@@ -146,7 +142,6 @@ describe('commands', () => {
 
       fixAction()
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(`"suspensive-react-query fix" is experimental feature`)
       expect(consoleLogSpy).toHaveBeenCalledWith('[@suspensive/react-query]', `The versions are compatible.`)
       expect(switchVersion).not.toHaveBeenCalled()
     })
@@ -158,7 +153,6 @@ describe('commands', () => {
 
       fixAction()
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(`"suspensive-react-query fix" is experimental feature`)
       expect(consoleLogSpy).toHaveBeenCalledWith('[@suspensive/react-query]', `Switching to the compatible version...`)
       expect(switchVersion).toHaveBeenCalledWith(5)
     })

--- a/packages/react-query/src/scripts/utils/commands.ts
+++ b/packages/react-query/src/scripts/utils/commands.ts
@@ -22,8 +22,6 @@ export const getSuspensiveReactQueryVersion = (): string => {
 }
 
 export const statusAction = () => {
-  console.warn(`"suspensive-react-query status" is experimental feature`)
-
   const packageJson = getPackageJson()
   const tanStackReactQueryPackageJson = getTanStackReactQueryPackageJson()
   const suspensiveReactQueryVersion = getSuspensiveReactQueryVersion()
@@ -50,8 +48,6 @@ export const statusAction = () => {
 }
 
 export const switchAction = (version: string) => {
-  console.warn(`"suspensive-react-query switch <version>" is experimental feature`)
-
   if (version === '4') {
     switchVersion(4)
   } else if (version === '5') {
@@ -62,8 +58,6 @@ export const switchAction = (version: string) => {
 }
 
 export const fixAction = () => {
-  console.warn(`"suspensive-react-query fix" is experimental feature`)
-
   const tanStackReactQueryPackageJson = getTanStackReactQueryPackageJson()
   const suspensiveReactQueryVersion = getSuspensiveReactQueryVersion()
 


### PR DESCRIPTION
close #1036 

# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

I stabilize all interfaces of @suspensive/react-query before @gwansikk trying Pull Request to add Suspensive as TanStack Query v5 Community Resources

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
