### PR TITLE
fix(suspensive.org): add defense code for github contributors fetching

### DIFF
--- a/docs/suspensive.org/src/lib/hooks/useFetchContributors.ts
+++ b/docs/suspensive.org/src/lib/hooks/useFetchContributors.ts
@@ -41,21 +41,36 @@ const useFetchContributors = () => {
           throw new Error('Failed to fetch contributors')
         }
         const data: GithubRepoContributor[] = (await response.json()) as GithubRepoContributor[]
-        if (Array.isArray(data) && data.length) {
-          const filteredContributors = data.filter((contributor) => {
-            const login = contributor.author.login
-            return !['github-actions[bot]', 'dependabot[bot]', 'renovate[bot]'].includes(login)
-          })
-          setResult({
-            data: filteredContributors,
-            error: undefined,
-            isError: false,
-            isLoading: false,
-            isSuccess: true,
-          })
+
+        if (!Array.isArray(data)) {
+          throw new Error('Data is not an array')
         }
+
+        if (data.length === 0) {
+          console.log('Github contributors data is empty')
+        }
+
+        const filteredContributors = data.filter((contributor) => {
+          const login = contributor.author.login
+          return !['github-actions[bot]', 'dependabot[bot]', 'renovate[bot]'].includes(login)
+        })
+
+        setResult({
+          data: filteredContributors,
+          error: undefined,
+          isError: false,
+          isLoading: false,
+          isSuccess: true,
+        })
       } catch (error) {
         console.error('Error fetching contributors:', error)
+        setResult({
+          data: undefined,
+          error: error as Error,
+          isError: true,
+          isLoading: false,
+          isSuccess: false,
+        })
       }
     }
 

--- a/docs/suspensive.org/src/lib/hooks/useFetchContributors.ts
+++ b/docs/suspensive.org/src/lib/hooks/useFetchContributors.ts
@@ -41,17 +41,19 @@ const useFetchContributors = () => {
           throw new Error('Failed to fetch contributors')
         }
         const data: GithubRepoContributor[] = (await response.json()) as GithubRepoContributor[]
-        const filteredContributors = data.filter((contributor) => {
-          const login = contributor.author.login
-          return !['github-actions[bot]', 'dependabot[bot]', 'renovate[bot]'].includes(login)
-        })
-        setResult({
-          data: filteredContributors,
-          error: undefined,
-          isError: false,
-          isLoading: false,
-          isSuccess: true,
-        })
+        if (Array.isArray(data) && data.length) {
+          const filteredContributors = data.filter((contributor) => {
+            const login = contributor.author.login
+            return !['github-actions[bot]', 'dependabot[bot]', 'renovate[bot]'].includes(login)
+          })
+          setResult({
+            data: filteredContributors,
+            error: undefined,
+            isError: false,
+            isLoading: false,
+            isSuccess: true,
+          })
+        }
       } catch (error) {
         console.error('Error fetching contributors:', error)
       }

--- a/docs/suspensive.org/src/lib/hooks/useFetchContributors.ts
+++ b/docs/suspensive.org/src/lib/hooks/useFetchContributors.ts
@@ -43,7 +43,7 @@ const useFetchContributors = () => {
         const data: GithubRepoContributor[] = (await response.json()) as GithubRepoContributor[]
 
         if (!Array.isArray(data)) {
-          throw new Error('Data is not an array')
+          throw new Error('Github contributors data is not an array')
         }
 
         if (data.length === 0) {


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Issue: https://github.com/toss/suspensive/issues/1051

I was able to reproduce the bug only by the time this issue was posted. Afterwards, I tried clearing the cache, browsing in secret mode, and even in another macbook (which never visited the page before) and in several browsers (chrome, safari, opera, edge),  I couldn't reproduce the bug again... for now I added some defense code to where the error log pointed:

![Captura de pantalla 2024-07-08 a las 8 02 06 p  m](https://github.com/toss/suspensive/assets/82362278/5e1b6343-e6aa-4dad-a102-35b08dd85d47)



I'll keep an eye on this issue. 

## PR Checklist

- [✅] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
