### PR TITLE
fix(react): add defineSuspense util function

### DIFF
--- a/.changeset/cold-wasps-hunt.md
+++ b/.changeset/cold-wasps-hunt.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react": patch
+---
+
+feat(react): fix clientOnly prop of Suspense with defaultProps

--- a/packages/react/src/Suspense.tsx
+++ b/packages/react/src/Suspense.tsx
@@ -1,13 +1,7 @@
-import { Suspense as ReactSuspense, type SuspenseProps as ReactSuspenseProps, useContext } from 'react'
-import { ClientOnly } from './components/ClientOnly'
+import { type SuspenseProps as ReactSuspenseProps, useContext } from 'react'
 import { SuspenseDefaultPropsContext, syncDevMode } from './contexts'
 import type { PropsWithDevMode } from './utility-types'
-
-const SuspenseClientOnly = (props: ReactSuspenseProps) => (
-  <ClientOnly fallback={props.fallback}>
-    <ReactSuspense {...props} />
-  </ClientOnly>
-)
+import { defineSuspense } from './utils/defineSuspense'
 
 export interface SuspenseProps extends PropsWithDevMode<ReactSuspenseProps, SuspenseDevModeProp> {
   /**
@@ -23,7 +17,10 @@ export interface SuspenseProps extends PropsWithDevMode<ReactSuspenseProps, Susp
  */
 export const Suspense = ({ clientOnly, devMode, children, fallback }: SuspenseProps) => {
   const defaultProps = useContext(SuspenseDefaultPropsContext)
-  const DefinedSuspense = defaultProps.clientOnly ?? clientOnly ? SuspenseClientOnly : ReactSuspense
+  const DefinedSuspense = defineSuspense({
+    defaultPropsClientOnly: defaultProps.clientOnly,
+    componentPropsClientOnly: clientOnly,
+  })
 
   return (
     <DefinedSuspense fallback={typeof fallback === 'undefined' ? defaultProps.fallback : fallback}>

--- a/packages/react/src/utils/defineSuspense.spec.ts
+++ b/packages/react/src/utils/defineSuspense.spec.ts
@@ -3,32 +3,28 @@ import { SuspenseClientOnly, defineSuspense } from './defineSuspense'
 
 describe('defineSuspense', () => {
   it('should return SuspenseClientOnly when componentPropsClientOnly is true', () => {
-    const DefinedSuspense = defineSuspense({ componentPropsClientOnly: true })
-    expect(DefinedSuspense).toBe(SuspenseClientOnly)
+    expect(defineSuspense({ componentPropsClientOnly: true })).toBe(SuspenseClientOnly)
+    expect(defineSuspense({ componentPropsClientOnly: true, defaultPropsClientOnly: undefined })).toBe(
+      SuspenseClientOnly
+    )
   })
-
   it('should return SuspenseClientOnly when defaultPropsClientOnly is true and componentPropsClientOnly is undefined', () => {
-    const DefinedSuspense = defineSuspense({ defaultPropsClientOnly: true })
-    expect(DefinedSuspense).toBe(SuspenseClientOnly)
+    expect(defineSuspense({ defaultPropsClientOnly: true })).toBe(SuspenseClientOnly)
+    expect(defineSuspense({ componentPropsClientOnly: undefined, defaultPropsClientOnly: true })).toBe(
+      SuspenseClientOnly
+    )
   })
-
   it('should return SuspenseClientOnly when defaultPropsClientOnly is false and componentPropsClientOnly is true', () => {
-    const DefinedSuspense = defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: true })
-    expect(DefinedSuspense).toBe(SuspenseClientOnly)
+    expect(defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: true })).toBe(SuspenseClientOnly)
   })
-
   it('should return Suspense when both defaultPropsClientOnly and componentPropsClientOnly are false', () => {
-    const DefinedSuspense = defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: false })
-    expect(DefinedSuspense).toBe(Suspense)
+    expect(defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: false })).toBe(Suspense)
   })
-
   it('should return Suspense when defaultPropsClientOnly is true and componentPropsClientOnly is false', () => {
-    const DefinedSuspense = defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: false })
-    expect(DefinedSuspense).toBe(Suspense)
+    expect(defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: false })).toBe(Suspense)
   })
-
   it('should return Suspense when both defaultPropsClientOnly and componentPropsClientOnly are undefined', () => {
-    const DefinedSuspense = defineSuspense({})
-    expect(DefinedSuspense).toBe(Suspense)
+    expect(defineSuspense({})).toBe(Suspense)
+    expect(defineSuspense({})).toBe(Suspense)
   })
 })

--- a/packages/react/src/utils/defineSuspense.spec.ts
+++ b/packages/react/src/utils/defineSuspense.spec.ts
@@ -1,0 +1,34 @@
+import { Suspense } from 'react'
+import { SuspenseClientOnly, defineSuspense } from './defineSuspense'
+
+describe('defineSuspense', () => {
+  it('should return SuspenseClientOnly when componentPropsClientOnly is true', () => {
+    const Component = defineSuspense({ componentPropsClientOnly: true })
+    expect(Component).toBe(SuspenseClientOnly)
+  })
+
+  it('should return SuspenseClientOnly when defaultPropsClientOnly is true and componentPropsClientOnly is undefined', () => {
+    const Component = defineSuspense({ defaultPropsClientOnly: true })
+    expect(Component).toBe(SuspenseClientOnly)
+  })
+
+  it('should return SuspenseClientOnly when defaultPropsClientOnly is false and componentPropsClientOnly is true', () => {
+    const Component = defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: true })
+    expect(Component).toBe(SuspenseClientOnly)
+  })
+
+  it('should return Suspense when both defaultPropsClientOnly and componentPropsClientOnly are false', () => {
+    const Component = defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: false })
+    expect(Component).toBe(Suspense)
+  })
+
+  it('should return Suspense when defaultPropsClientOnly is true and componentPropsClientOnly is false', () => {
+    const Component = defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: false })
+    expect(Component).toBe(Suspense)
+  })
+
+  it('should return Suspense when both defaultPropsClientOnly and componentPropsClientOnly are undefined', () => {
+    const Component = defineSuspense({})
+    expect(Component).toBe(Suspense)
+  })
+})

--- a/packages/react/src/utils/defineSuspense.spec.ts
+++ b/packages/react/src/utils/defineSuspense.spec.ts
@@ -3,32 +3,32 @@ import { SuspenseClientOnly, defineSuspense } from './defineSuspense'
 
 describe('defineSuspense', () => {
   it('should return SuspenseClientOnly when componentPropsClientOnly is true', () => {
-    const Component = defineSuspense({ componentPropsClientOnly: true })
-    expect(Component).toBe(SuspenseClientOnly)
+    const DefinedSuspense = defineSuspense({ componentPropsClientOnly: true })
+    expect(DefinedSuspense).toBe(SuspenseClientOnly)
   })
 
   it('should return SuspenseClientOnly when defaultPropsClientOnly is true and componentPropsClientOnly is undefined', () => {
-    const Component = defineSuspense({ defaultPropsClientOnly: true })
-    expect(Component).toBe(SuspenseClientOnly)
+    const DefinedSuspense = defineSuspense({ defaultPropsClientOnly: true })
+    expect(DefinedSuspense).toBe(SuspenseClientOnly)
   })
 
   it('should return SuspenseClientOnly when defaultPropsClientOnly is false and componentPropsClientOnly is true', () => {
-    const Component = defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: true })
-    expect(Component).toBe(SuspenseClientOnly)
+    const DefinedSuspense = defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: true })
+    expect(DefinedSuspense).toBe(SuspenseClientOnly)
   })
 
   it('should return Suspense when both defaultPropsClientOnly and componentPropsClientOnly are false', () => {
-    const Component = defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: false })
-    expect(Component).toBe(Suspense)
+    const DefinedSuspense = defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: false })
+    expect(DefinedSuspense).toBe(Suspense)
   })
 
   it('should return Suspense when defaultPropsClientOnly is true and componentPropsClientOnly is false', () => {
-    const Component = defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: false })
-    expect(Component).toBe(Suspense)
+    const DefinedSuspense = defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: false })
+    expect(DefinedSuspense).toBe(Suspense)
   })
 
   it('should return Suspense when both defaultPropsClientOnly and componentPropsClientOnly are undefined', () => {
-    const Component = defineSuspense({})
-    expect(Component).toBe(Suspense)
+    const DefinedSuspense = defineSuspense({})
+    expect(DefinedSuspense).toBe(Suspense)
   })
 })

--- a/packages/react/src/utils/defineSuspense.test-d.ts
+++ b/packages/react/src/utils/defineSuspense.test-d.ts
@@ -1,0 +1,30 @@
+import type { Suspense } from 'react'
+import { type SuspenseClientOnly, defineSuspense } from './defineSuspense'
+
+describe('defineSuspense', () => {
+  it('type check', () => {
+    expectTypeOf(defineSuspense({ componentPropsClientOnly: true })).toEqualTypeOf<typeof SuspenseClientOnly>()
+    expectTypeOf(defineSuspense({ defaultPropsClientOnly: true })).toEqualTypeOf<typeof SuspenseClientOnly>()
+    expectTypeOf(defineSuspense({ componentPropsClientOnly: true, defaultPropsClientOnly: undefined })).toEqualTypeOf<
+      typeof SuspenseClientOnly
+    >()
+    expectTypeOf(defineSuspense({ componentPropsClientOnly: undefined, defaultPropsClientOnly: true })).toEqualTypeOf<
+      typeof SuspenseClientOnly
+    >()
+    expectTypeOf(defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: true })).toEqualTypeOf<
+      typeof SuspenseClientOnly
+    >()
+    expectTypeOf(defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: false })).toEqualTypeOf<
+      typeof SuspenseClientOnly
+    >()
+    expectTypeOf(defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: true })).toEqualTypeOf<
+      typeof SuspenseClientOnly
+    >()
+    expectTypeOf(defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: false })).toEqualTypeOf<
+      typeof Suspense
+    >()
+    expectTypeOf(
+      defineSuspense({ defaultPropsClientOnly: undefined, componentPropsClientOnly: undefined })
+    ).toEqualTypeOf<typeof Suspense>()
+  })
+})

--- a/packages/react/src/utils/defineSuspense.tsx
+++ b/packages/react/src/utils/defineSuspense.tsx
@@ -7,10 +7,41 @@ export const SuspenseClientOnly = (props: SuspenseProps) => (
   </ClientOnly>
 )
 
-export const defineSuspense = ({
+/* eslint-disable @typescript-eslint/unified-signatures */
+export function defineSuspense(options: { componentPropsClientOnly: true }): typeof SuspenseClientOnly
+export function defineSuspense(options: { defaultPropsClientOnly: true }): typeof SuspenseClientOnly
+export function defineSuspense(options: {
+  componentPropsClientOnly: true
+  defaultPropsClientOnly: undefined
+}): typeof SuspenseClientOnly
+export function defineSuspense(options: {
+  componentPropsClientOnly: undefined
+  defaultPropsClientOnly: true
+}): typeof SuspenseClientOnly
+export function defineSuspense(options: {
+  componentPropsClientOnly: true
+  defaultPropsClientOnly: true
+}): typeof SuspenseClientOnly
+export function defineSuspense(options: {
+  componentPropsClientOnly: true
+  defaultPropsClientOnly: false
+}): typeof SuspenseClientOnly
+export function defineSuspense(options: {
+  componentPropsClientOnly: false
+  defaultPropsClientOnly: true
+}): typeof SuspenseClientOnly
+export function defineSuspense(options: {
+  componentPropsClientOnly: false
+  defaultPropsClientOnly: false
+}): typeof Suspense
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function defineSuspense(options: {}): typeof Suspense
+export function defineSuspense({
   defaultPropsClientOnly,
   componentPropsClientOnly,
 }: {
   defaultPropsClientOnly?: boolean
   componentPropsClientOnly?: boolean
-}) => (componentPropsClientOnly ?? defaultPropsClientOnly ? SuspenseClientOnly : Suspense)
+}): typeof SuspenseClientOnly | typeof Suspense {
+  return componentPropsClientOnly ?? defaultPropsClientOnly ? SuspenseClientOnly : Suspense
+}

--- a/packages/react/src/utils/defineSuspense.tsx
+++ b/packages/react/src/utils/defineSuspense.tsx
@@ -7,7 +7,10 @@ export const SuspenseClientOnly = (props: SuspenseProps) => (
   </ClientOnly>
 )
 
-export const defineSuspense = ({ defaultPropsClientOnly, componentPropsClientOnly }: {
+export const defineSuspense = ({
+  defaultPropsClientOnly,
+  componentPropsClientOnly,
+}: {
   defaultPropsClientOnly?: boolean
   componentPropsClientOnly?: boolean
-}) => componentPropsClientOnly ?? defaultPropsClientOnly ? SuspenseClientOnly : Suspense
+}) => (componentPropsClientOnly ?? defaultPropsClientOnly ? SuspenseClientOnly : Suspense)

--- a/packages/react/src/utils/defineSuspense.tsx
+++ b/packages/react/src/utils/defineSuspense.tsx
@@ -1,17 +1,13 @@
 import { Suspense, type SuspenseProps } from 'react'
 import { ClientOnly } from '../components/ClientOnly'
 
-interface DefineSuspenseProps {
-  defaultPropsClientOnly?: boolean
-  componentPropsClientOnly?: boolean
-}
-
 export const SuspenseClientOnly = (props: SuspenseProps) => (
   <ClientOnly fallback={props.fallback}>
     <Suspense {...props} />
   </ClientOnly>
 )
 
-export const defineSuspense = ({ defaultPropsClientOnly, componentPropsClientOnly }: DefineSuspenseProps) => {
-  return componentPropsClientOnly ?? defaultPropsClientOnly ? SuspenseClientOnly : Suspense
-}
+export const defineSuspense = ({ defaultPropsClientOnly, componentPropsClientOnly }: {
+  defaultPropsClientOnly?: boolean
+  componentPropsClientOnly?: boolean
+}) => componentPropsClientOnly ?? defaultPropsClientOnly ? SuspenseClientOnly : Suspense

--- a/packages/react/src/utils/defineSuspense.tsx
+++ b/packages/react/src/utils/defineSuspense.tsx
@@ -1,0 +1,17 @@
+import { Suspense, type SuspenseProps } from 'react'
+import { ClientOnly } from '../components/ClientOnly'
+
+interface DefineSuspenseProps {
+  defaultPropsClientOnly?: boolean
+  componentPropsClientOnly?: boolean
+}
+
+export const SuspenseClientOnly = (props: SuspenseProps) => (
+  <ClientOnly fallback={props.fallback}>
+    <Suspense {...props} />
+  </ClientOnly>
+)
+
+export const defineSuspense = ({ defaultPropsClientOnly, componentPropsClientOnly }: DefineSuspenseProps) => {
+  return componentPropsClientOnly ?? defaultPropsClientOnly ? SuspenseClientOnly : Suspense
+}


### PR DESCRIPTION
close: #1058

# Overview
Add the `defineSuspense` utility function discussed in the issue article above, and write the test code.

The reason we defined `SuspenseClientOnly` within `defineSuspense` is because we are getting the `"dependency cycle detected"` issue. 

If you have any additional thoughts on the above issues, please let us know!

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
