### PR TITLE
feat(cache): add DataTag type to cacheOptions

### DIFF
--- a/.changeset/little-doors-drive.md
+++ b/.changeset/little-doors-drive.md
@@ -2,4 +2,4 @@
 '@suspensive/cache': minor
 ---
 
-feat(cache): add DataTag type to cacheOptions
+feat(cache): add DataTag feature of cacheOptions

--- a/.changeset/little-doors-drive.md
+++ b/.changeset/little-doors-drive.md
@@ -1,0 +1,5 @@
+---
+'@suspensive/cache': patch
+---
+
+feat(cache): add DataTag type to cacheOptions

--- a/.changeset/little-doors-drive.md
+++ b/.changeset/little-doors-drive.md
@@ -1,5 +1,5 @@
 ---
-'@suspensive/cache': patch
+'@suspensive/cache': minor
 ---
 
 feat(cache): add DataTag type to cacheOptions

--- a/packages/cache/src/cacheOptions.test-d.tsx
+++ b/packages/cache/src/cacheOptions.test-d.tsx
@@ -1,14 +1,9 @@
 import { expectTypeOf } from 'vitest'
 import { Cache } from './Cache'
 import { cacheOptions } from './cacheOptions'
+import type { ResolvedCached } from './CacheStore'
 import { dataTagSymbol } from './types'
 import { useCache } from './useCache'
-
-interface ResolvedCachedState<TData> {
-  promise: Promise<TData>
-  data: TData
-  error: undefined
-}
 
 const key = (id: number) => ['key', id] as const
 
@@ -23,7 +18,7 @@ describe('cacheOptions', () => {
     ;(() => (
       <Cache {...cache()}>
         {(cached) => {
-          expectTypeOf(cached).toEqualTypeOf<ResolvedCachedState<number>>()
+          expectTypeOf(cached).toEqualTypeOf<ResolvedCached<number>['state']>()
           expectTypeOf(cached.data).toEqualTypeOf<number>()
           return <></>
         }}
@@ -33,7 +28,7 @@ describe('cacheOptions', () => {
 
   it('should be used with useCache', () => {
     const cached = useCache(cache())
-    expectTypeOf(cached).toEqualTypeOf<ResolvedCachedState<number>>()
+    expectTypeOf(cached).toEqualTypeOf<ResolvedCached<number>['state']>()
     expectTypeOf(cached.data).toEqualTypeOf<number>()
   })
 

--- a/packages/cache/src/cacheOptions.test-d.tsx
+++ b/packages/cache/src/cacheOptions.test-d.tsx
@@ -1,0 +1,46 @@
+import { expectTypeOf } from 'vitest'
+import { Cache } from './Cache'
+import { cacheOptions } from './cacheOptions'
+import { dataTagSymbol } from './types'
+import { useCache } from './useCache'
+
+interface ResolvedCachedState<TData> {
+  promise: Promise<TData>
+  data: TData
+  error: undefined
+}
+
+const key = (id: number) => ['key', id] as const
+
+const cache = () =>
+  cacheOptions({
+    cacheKey: key(1),
+    cacheFn: () => Promise.resolve(5),
+  })
+
+describe('cacheOptions', () => {
+  it('should be used with <Cache />', () => {
+    ;(() => (
+      <Cache {...cache()}>
+        {(cached) => {
+          expectTypeOf(cached).toEqualTypeOf<ResolvedCachedState<number>>()
+          expectTypeOf(cached.data).toEqualTypeOf<number>()
+          return <></>
+        }}
+      </Cache>
+    ))()
+  })
+
+  it('should be used with useCache', () => {
+    const cached = useCache(cache())
+    expectTypeOf(cached).toEqualTypeOf<ResolvedCachedState<number>>()
+    expectTypeOf(cached.data).toEqualTypeOf<number>()
+  })
+
+  it('should tag the cacheKey with the result type of the cacheFn', () => {
+    expect(() => {
+      const { cacheKey } = cache()
+      expectTypeOf(cacheKey[dataTagSymbol]).toEqualTypeOf<number>()
+    })
+  })
+})

--- a/packages/cache/src/cacheOptions.test-d.tsx
+++ b/packages/cache/src/cacheOptions.test-d.tsx
@@ -32,10 +32,9 @@ describe('cacheOptions', () => {
     expectTypeOf(cached.data).toEqualTypeOf<number>()
   })
 
-  it('should tag the cacheKey with the result type of the cacheFn', () => {
+  it('should add DataTag on cacheKey with ReturnType<typeof cacheFn>', () => {
     expect(() => {
-      const { cacheKey } = cache()
-      expectTypeOf(cacheKey[dataTagSymbol]).toEqualTypeOf<number>()
+      expectTypeOf(cache().cacheKey[dataTagSymbol]).toEqualTypeOf<number>()
     })
   })
 })

--- a/packages/cache/src/cacheOptions.ts
+++ b/packages/cache/src/cacheOptions.ts
@@ -1,10 +1,17 @@
-import type { CacheKey, CacheOptions } from './types'
+import type { CacheKey, CacheOptions, DataTag } from './types'
 
 /**
  * @experimental This is experimental feature.
  */
 export function cacheOptions<TData, TCacheKey extends CacheKey>(
   options: CacheOptions<TData, TCacheKey>
-): CacheOptions<TData, TCacheKey> {
+): CacheOptions<TData, TCacheKey> & {
+  cacheKey: DataTag<TCacheKey, TData>
+}
+
+/**
+ * @experimental This is experimental feature.
+ */
+export function cacheOptions(options: unknown) {
   return options
 }

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -5,7 +5,12 @@ export type CacheKey = Tuple
 /**
  * @experimental This is experimental feature.
  */
-export type CacheOptions<TData, TCacheKey extends CacheKey> = {
+export interface CacheOptions<TData, TCacheKey extends CacheKey> {
   cacheKey: TCacheKey
   cacheFn: (options: { cacheKey: TCacheKey }) => Promise<TData>
+}
+
+export declare const dataTagSymbol: unique symbol
+export type DataTag<TType, TValue> = TType & {
+  [dataTagSymbol]: TValue
 }


### PR DESCRIPTION
# Overview
close #1088

- add DataTag type to cacheOptions
- add tests for cacheOptions
- ref: https://tkdodo.eu/blog/the-query-options-api

## Test
![image](https://github.com/user-attachments/assets/2115a6d9-6fca-482d-8bab-5eac83fa0825)

**This case is when you put only cacheKey in the parameter.**

I created a function called getCache for testing purposes and confirmed that type inference works well using cacheOptions during testing.
<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
