### PR TITLE
chore: update permissions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
   quality:
     name: Check quality
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       matrix:
         command:


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Fix [this error](https://github.com/toss/suspensive/actions/runs/10123937476/job/27997896523?pr=1151).

I referred to this [stackoverflow](https://stackoverflow.com/questions/70435286/resource-not-accessible-by-integration-on-github-post-repos-owner-repo-ac/76994510#76994510).

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
