### PR TITLE
chore: remove actions-next-bundle analyzer in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,3 @@ jobs:
           pattern: 'packages/**/dist/*.{js,cjs,mjs}'
           exclude: '{**/*.map,**/node_modules/**}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: matrix.command == 'build'
-        uses: transferwise/actions-next-bundle-analyzer@v2
-        with:
-          working-directory: ./websites/visualization
-          comment-strategy: 'always'
-          create-issue: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
   quality:
     name: Check quality
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     strategy:
       matrix:
         command:


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Related with https://github.com/toss/suspensive/pull/1157#issuecomment-2254481894

Remove actions-next-bundle analyzer in CI.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
