### PR TITLE
fix(cache): remove unsubscribe method of CacheStore

### DIFF
--- a/.changeset/chilled-pets-hunt.md
+++ b/.changeset/chilled-pets-hunt.md
@@ -2,4 +2,4 @@
 '@suspensive/cache': patch
 ---
 
-chore(cache): remove unsubscribe method
+chore(cache): remove unsubscribe method of CacheStore

--- a/.changeset/chilled-pets-hunt.md
+++ b/.changeset/chilled-pets-hunt.md
@@ -1,0 +1,5 @@
+---
+'@suspensive/cache': patch
+---
+
+chore(cache): remove unsubscribe method

--- a/.changeset/chilled-pets-hunt.md
+++ b/.changeset/chilled-pets-hunt.md
@@ -2,4 +2,4 @@
 '@suspensive/cache': patch
 ---
 
-chore(cache): remove unsubscribe method of CacheStore
+fix(cache): remove unsubscribe method of CacheStore

--- a/packages/cache/src/CacheStore.ts
+++ b/packages/cache/src/CacheStore.ts
@@ -57,14 +57,22 @@ export type AllStatusCached<TData, TCacheKey extends CacheKey = CacheKey> =
       }
     }
 
-export interface IdleCached<TData, TCacheKey extends CacheKey = CacheKey>
-  extends ExtractPartial<AllStatusCached<TData, TCacheKey>, { status: CacheStatus.Idle }> {}
-export interface PendingCached<TData, TCacheKey extends CacheKey = CacheKey>
-  extends ExtractPartial<AllStatusCached<TData, TCacheKey>, { status: CacheStatus.Pending }> {}
-export interface ResolvedCached<TData, TCacheKey extends CacheKey = CacheKey>
-  extends ExtractPartial<AllStatusCached<TData, TCacheKey>, { status: CacheStatus.Resolved }> {}
-export interface RejectedCached<TData, TCacheKey extends CacheKey = CacheKey>
-  extends ExtractPartial<AllStatusCached<TData, TCacheKey>, { status: CacheStatus.Rejected }> {}
+export type IdleCached<TData, TCacheKey extends CacheKey = CacheKey> = ExtractPartial<
+  AllStatusCached<TData, TCacheKey>,
+  { status: CacheStatus.Idle }
+>
+export type PendingCached<TData, TCacheKey extends CacheKey = CacheKey> = ExtractPartial<
+  AllStatusCached<TData, TCacheKey>,
+  { status: CacheStatus.Pending }
+>
+export type ResolvedCached<TData, TCacheKey extends CacheKey = CacheKey> = ExtractPartial<
+  AllStatusCached<TData, TCacheKey>,
+  { status: CacheStatus.Resolved }
+>
+export type RejectedCached<TData, TCacheKey extends CacheKey = CacheKey> = ExtractPartial<
+  AllStatusCached<TData, TCacheKey>,
+  { status: CacheStatus.Rejected }
+>
 
 export type Cached<TData, TCacheKey extends CacheKey = CacheKey> =
   | IdleCached<TData, TCacheKey>
@@ -191,22 +199,15 @@ export class CacheStore {
     const syncs = this.syncsMap.get(hashedCacheKey)
     this.syncsMap.set(hashedCacheKey, [...(syncs ?? []), syncSubscriber])
 
-    const subscribed = {
-      unsubscribe: () => this.unsubscribe(options, syncSubscriber),
+    const unsubscribe = () => {
+      if (syncs) {
+        this.syncsMap.set(
+          hashedCacheKey,
+          syncs.filter((sync) => sync !== syncSubscriber)
+        )
+      }
     }
-    return subscribed
-  }
-
-  public unsubscribe(options: Pick<CacheOptions<unknown, CacheKey>, 'cacheKey'>, syncSubscriber: Sync) {
-    const hashedCacheKey = hashCacheKey(options.cacheKey)
-    const syncs = this.syncsMap.get(hashedCacheKey)
-
-    if (syncs) {
-      this.syncsMap.set(
-        hashedCacheKey,
-        syncs.filter((sync) => sync !== syncSubscriber)
-      )
-    }
+    return unsubscribe
   }
 
   private syncSubscribers = (cacheKey?: CacheKey) => {

--- a/packages/cache/src/useCache.ts
+++ b/packages/cache/src/useCache.ts
@@ -11,7 +11,7 @@ export function useCache<TData, TCacheKey extends CacheKey>(
 ): ResolvedCached<TData, TCacheKey>['state'] {
   const cacheStore = useCacheStore()
   return useSyncExternalStore<ResolvedCached<TData, TCacheKey>>(
-    (sync) => cacheStore.subscribe(options, sync).unsubscribe,
+    (sync) => cacheStore.subscribe(options, sync),
     () => cacheStore.suspend<TData, TCacheKey>(options),
     () => cacheStore.suspend<TData, TCacheKey>(options)
   ).state


### PR DESCRIPTION
# Overview
- remove unsubscribe method

The unsubscribe method does not need to be visible to the user as a public method. Therefore, it will be hidden within the subscribe method, and the unsubscribe method will be removed.
<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
