### PR TITLE
docs(suspensive.org): update callout for "support both TanStack Query v4 and v5"

### DIFF
--- a/docs/suspensive.org/src/pages/docs/react-query/motivation.en.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/motivation.en.mdx
@@ -15,7 +15,7 @@ import { Steps } from 'nextra/components'
 
 <Callout type='info'>
 
-From version 2.2.0 onwards, @tanstack/react-query supports both v4 and v5. To support older browser versions, use @tanstack/react-query v4.
+From version 2.2.0 onwards, @tanstack/react-query supports both v4 and v5. To support older browser versions, use @suspensive/react-query with @tanstack/react-query v4.
 
 </Callout>
 

--- a/docs/suspensive.org/src/pages/docs/react-query/motivation.ko.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/motivation.ko.mdx
@@ -15,7 +15,7 @@ import { Steps } from 'nextra/components'
 
 <Callout type='info'>
 
-@tanstack/react-query@2.2.0 버전 이후로는 @tanstack/react-query v4와 v5을 모두 지원합니다. 더 낮은 버전의 브라우저를 지원하려면 @tanstack/react-query v4를 사용하세요.
+2.2.0 버전 이후로는 @tanstack/react-query v4와 v5을 모두 지원합니다. 더 낮은 버전의 브라우저를 지원하려면 @suspensive/react-query를 @tanstack/react-query v4와 함께 사용하세요.
 
 </Callout>
 

--- a/docs/suspensive.org/src/pages/docs/react-query/tanstack-query-compatibility.ko.mdx
+++ b/docs/suspensive.org/src/pages/docs/react-query/tanstack-query-compatibility.ko.mdx
@@ -4,7 +4,7 @@ import { Callout } from '@/components'
 
 <Callout type='info'>
 
-@tanstack/react-query@2.2.0 버전 이후로는 @tanstack/react-query v4와 v5을 모두 지원합니다. 더 낮은 버전의 브라우저를 지원하려면 @suspensive/react-query를 @tanstack/react-query v4와 함께 사용하세요.
+2.2.0 버전 이후로는 @tanstack/react-query v4와 v5을 모두 지원합니다. 더 낮은 버전의 브라우저를 지원하려면 @suspensive/react-query를 @tanstack/react-query v4와 함께 사용하세요.
 
 </Callout>
 


### PR DESCRIPTION
# Overview

- I deleted the callout where "@suspensive/react-query@2.2.0" was incorrectly written as "@tanstack/react-query@2.2.0".
- I have standardized the callout content for "Support both TanStack Query v4 and 5".

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
