### PR TITLE
feat(jotai): escape version 0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,8 @@
       "@suspensive/react",
       "@suspensive/react-query",
       "@suspensive/react-query-4",
-      "@suspensive/react-query-5"
+      "@suspensive/react-query-5",
+      "@suspensive/jotai"
     ]
   ],
   "ignore": [

--- a/.changeset/gentle-moles-wink.md
+++ b/.changeset/gentle-moles-wink.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/jotai": minor
+---
+
+feat(jotai): improve jotai package for 1.0.0 release

--- a/.changeset/gentle-moles-wink.md
+++ b/.changeset/gentle-moles-wink.md
@@ -2,4 +2,4 @@
 "@suspensive/jotai": minor
 ---
 
-feat(jotai): improve jotai package for 1.0.0 release
+feat(jotai): escape version 0

--- a/docs/suspensive.org/src/pages/docs/jotai/Atom.en.mdx
+++ b/docs/suspensive.org/src/pages/docs/jotai/Atom.en.mdx
@@ -2,12 +2,6 @@ import { Callout } from '@/components'
 
 # Atom
 
-<Callout type='experimental'>
-
-`<Atom/>` is an experimental feature, so this interface may change.
-
-</Callout>
-
 The Atom component provides an interface similar to Jotai's [useAtom](https://jotai.org/docs/core/use-atom#useatom) hook as props, allowing declarative usage.
 
 ### props.atom

--- a/docs/suspensive.org/src/pages/docs/jotai/Atom.ko.mdx
+++ b/docs/suspensive.org/src/pages/docs/jotai/Atom.ko.mdx
@@ -2,12 +2,6 @@ import { Callout } from '@/components'
 
 # Atom
 
-<Callout type='experimental'>
-
-`<Atom/>`는 실험 기능이므로 이 인터페이스는 변경될 수 있습니다.
-
-</Callout>
-
 Atom 컴포넌트는 Jotai의 [useAtom](https://jotai.org/docs/core/use-atom#useatom) 훅과 동일한 인터페이스를 Props로 제공하며 선언적으로 사용할 수 있습니다.
 
 ### props.atom

--- a/docs/suspensive.org/src/pages/docs/jotai/AtomValue.en.mdx
+++ b/docs/suspensive.org/src/pages/docs/jotai/AtomValue.en.mdx
@@ -2,12 +2,6 @@ import { Callout } from '@/components'
 
 # AtomValue
 
-<Callout type='experimental'>
-
-`<AtomValue/>` is an experimental feature, so this interface may change.
-
-</Callout>
-
 The AtomValue component provides an interface similar to Jotai's [useAtomValue](https://jotai.org/docs/core/use-atom#useatomvalue) hook as props, allowing declarative usage.
 
 ### props.atom

--- a/docs/suspensive.org/src/pages/docs/jotai/AtomValue.ko.mdx
+++ b/docs/suspensive.org/src/pages/docs/jotai/AtomValue.ko.mdx
@@ -2,12 +2,6 @@ import { Callout } from '@/components'
 
 # AtomValue
 
-<Callout type='experimental'>
-
-`<AtomValue/>`는 실험 기능이므로 이 인터페이스는 변경될 수 있습니다.
-
-</Callout>
-
 AtomValue 컴포넌트는 Jotai의 [useAtomValue](https://jotai.org/docs/core/use-atom#useatomvalue) 훅과 동일한 인터페이스를 Props로 제공하며 선언적으로 사용할 수 있습니다.
 
 ### props.atom

--- a/docs/suspensive.org/src/pages/docs/jotai/SetAtom.en.mdx
+++ b/docs/suspensive.org/src/pages/docs/jotai/SetAtom.en.mdx
@@ -2,12 +2,6 @@ import { Callout } from '@/components'
 
 # SetAtom
 
-<Callout type='experimental'>
-
-`<SetAtom/>` is an experimental feature, so this interface may change.
-
-</Callout>
-
 The SetAtom component provides an interface similar to Jotai's [useSetAtom](https://jotai.org/docs/core/use-atom#usesetatom) hook as props, allowing declarative usage.
 
 ### props.atom

--- a/docs/suspensive.org/src/pages/docs/jotai/SetAtom.ko.mdx
+++ b/docs/suspensive.org/src/pages/docs/jotai/SetAtom.ko.mdx
@@ -2,12 +2,6 @@ import { Callout } from '@/components'
 
 # SetAtom
 
-<Callout type='experimental'>
-
-`<SetAtom/>`는 실험 기능이므로 이 인터페이스는 변경될 수 있습니다.
-
-</Callout>
-
 SetAtom 컴포넌트는 Jotai의 [useSetAtom](https://jotai.org/docs/core/use-atom#usesetatom) 훅과 동일한 인터페이스를 Props로 제공하며 선언적으로 사용할 수 있습니다.
 
 ### props.atom

--- a/packages/jotai/src/Atom.test-d.tsx
+++ b/packages/jotai/src/Atom.test-d.tsx
@@ -1,13 +1,16 @@
 import { atom, useAtom } from 'jotai'
+import { loadable } from 'jotai/utils'
 import type { ReactNode } from 'react'
 import { Atom } from './Atom'
 
 const countAtom = atom(0)
+const readOnlyCountAtom = atom((get) => get(countAtom))
+const writeOnlyCountAtom = atom(null, (get, set) => set(countAtom, get(countAtom) + 1))
 const asyncAtom = atom(async () => Promise.resolve('string'))
-// eslint-disable-next-line @typescript-eslint/require-await
 const asyncIncrementAtom = atom(null, async (get, set) => {
   set(countAtom, get(countAtom) + 1)
 })
+const loadableAtom = loadable(asyncAtom)
 
 describe('<Atom/>', () => {
   it('type check', () => {
@@ -15,6 +18,24 @@ describe('<Atom/>', () => {
       <Atom atom={countAtom}>
         {(result) => {
           const returnOfJotai = useAtom(countAtom)
+          expectTypeOf(result).toEqualTypeOf<typeof returnOfJotai>()
+          return <></>
+        }}
+      </Atom>
+    )
+    ;() => (
+      <Atom atom={readOnlyCountAtom}>
+        {(result) => {
+          const returnOfJotai = useAtom(readOnlyCountAtom)
+          expectTypeOf(result).toEqualTypeOf<typeof returnOfJotai>()
+          return <></>
+        }}
+      </Atom>
+    )
+    ;() => (
+      <Atom atom={writeOnlyCountAtom}>
+        {(result) => {
+          const returnOfJotai = useAtom(writeOnlyCountAtom)
           expectTypeOf(result).toEqualTypeOf<typeof returnOfJotai>()
           return <></>
         }}
@@ -38,12 +59,27 @@ describe('<Atom/>', () => {
         }}
       </Atom>
     )
+    ;() => (
+      <Atom atom={loadableAtom}>
+        {(result) => {
+          const returnOfJotai = useAtom(loadableAtom)
+          expectTypeOf(result).toEqualTypeOf<typeof returnOfJotai>()
+          return <></>
+        }}
+      </Atom>
+    )
 
     expectTypeOf(<Atom atom={countAtom}>{() => <></>}</Atom>).toEqualTypeOf<JSX.Element>()
     expectTypeOf(<Atom atom={countAtom}>{() => <></>}</Atom>).not.toEqualTypeOf<ReactNode>()
+    expectTypeOf(<Atom atom={readOnlyCountAtom}>{() => <></>}</Atom>).toEqualTypeOf<JSX.Element>()
+    expectTypeOf(<Atom atom={readOnlyCountAtom}>{() => <></>}</Atom>).not.toEqualTypeOf<ReactNode>()
+    expectTypeOf(<Atom atom={writeOnlyCountAtom}>{() => <></>}</Atom>).toEqualTypeOf<JSX.Element>()
+    expectTypeOf(<Atom atom={writeOnlyCountAtom}>{() => <></>}</Atom>).not.toEqualTypeOf<ReactNode>()
     expectTypeOf(<Atom atom={asyncAtom}>{() => <></>}</Atom>).toEqualTypeOf<JSX.Element>()
     expectTypeOf(<Atom atom={asyncAtom}>{() => <></>}</Atom>).not.toEqualTypeOf<ReactNode>()
     expectTypeOf(<Atom atom={asyncIncrementAtom}>{() => <></>}</Atom>).toEqualTypeOf<JSX.Element>()
     expectTypeOf(<Atom atom={asyncIncrementAtom}>{() => <></>}</Atom>).not.toEqualTypeOf<ReactNode>()
+    expectTypeOf(<Atom atom={loadableAtom}>{() => <></>}</Atom>).toEqualTypeOf<JSX.Element>()
+    expectTypeOf(<Atom atom={loadableAtom}>{() => <></>}</Atom>).not.toEqualTypeOf<ReactNode>()
   })
 })

--- a/packages/jotai/src/Atom.tsx
+++ b/packages/jotai/src/Atom.tsx
@@ -12,28 +12,26 @@ import {
   useSetAtom,
 } from 'jotai'
 import type { ReactNode } from 'react'
-import type { ChildrenRenderProps } from './utility-types'
+import type { ChildrenRenderProps, SetAtom } from './utility-types'
 
 type UseAtomProps<TAtom extends Parameters<typeof useAtom>[0]> = {
   atom: TAtom
   options?: Parameters<typeof useAtom>[1]
 }
 
-type TSetAtom<TArgs extends unknown[], TResult> = (...args: TArgs) => TResult
-
 export function Atom<TValue, TArgs extends unknown[], TResult>({
   children,
   atom,
   options,
 }: UseAtomProps<WritableAtom<TValue, TArgs, TResult>> &
-  ChildrenRenderProps<[Awaited<TValue>, TSetAtom<TArgs, TResult>]>): ReactNode
+  ChildrenRenderProps<[Awaited<TValue>, SetAtom<TArgs, TResult>]>): ReactNode
 
 export function Atom<TValue>({
   children,
   atom,
   options,
 }: UseAtomProps<PrimitiveAtom<TValue>> &
-  ChildrenRenderProps<[Awaited<TValue>, TSetAtom<[SetStateAction<TValue>], void>]>): ReactNode
+  ChildrenRenderProps<[Awaited<TValue>, SetAtom<[SetStateAction<TValue>], void>]>): ReactNode
 
 export function Atom<TValue>({
   children,
@@ -47,7 +45,7 @@ export function Atom<TAtom extends WritableAtom<unknown, never[], unknown>>({
   options,
 }: UseAtomProps<TAtom> &
   ChildrenRenderProps<
-    [Awaited<ExtractAtomValue<TAtom>>, TSetAtom<ExtractAtomArgs<TAtom>, ExtractAtomResult<TAtom>>]
+    [Awaited<ExtractAtomValue<TAtom>>, SetAtom<ExtractAtomArgs<TAtom>, ExtractAtomResult<TAtom>>]
   >): ReactNode
 
 export function Atom<TAtom extends JotaiAtom<unknown>>({

--- a/packages/jotai/src/Atom.tsx
+++ b/packages/jotai/src/Atom.tsx
@@ -13,69 +13,55 @@ import {
 } from 'jotai'
 import type { ReactNode } from 'react'
 import type { ChildrenRenderProps } from './utility-types'
-type UseAtomProps<TAtom extends JotaiAtom<unknown>> = {
+
+type UseAtomProps<TAtom extends Parameters<typeof useAtom>[0]> = {
   atom: TAtom
   options?: Parameters<typeof useAtom>[1]
 }
 
-/**
- * @experimental This is experimental feature.
- */
+type TSetAtom<TArgs extends unknown[], TResult> = (...args: TArgs) => TResult
+
 export function Atom<TValue, TArgs extends unknown[], TResult>({
   children,
   atom,
   options,
 }: UseAtomProps<WritableAtom<TValue, TArgs, TResult>> &
-  ChildrenRenderProps<[Awaited<TValue>, (...args: TArgs) => TResult]>): ReactNode
+  ChildrenRenderProps<[Awaited<TValue>, TSetAtom<TArgs, TResult>]>): ReactNode
 
-/**
- * @experimental This is experimental feature.
- */
 export function Atom<TValue>({
   children,
   atom,
   options,
 }: UseAtomProps<PrimitiveAtom<TValue>> &
-  ChildrenRenderProps<[Awaited<TValue>, (...args: [SetStateAction<TValue>]) => void]>): ReactNode
+  ChildrenRenderProps<[Awaited<TValue>, TSetAtom<[SetStateAction<TValue>], void>]>): ReactNode
 
-/**
- * @experimental This is experimental feature.
- */
 export function Atom<TValue>({
   children,
   atom,
   options,
 }: UseAtomProps<JotaiAtom<TValue>> & ChildrenRenderProps<[Awaited<TValue>, never]>): ReactNode
 
-/**
- * @experimental This is experimental feature.
- */
 export function Atom<TAtom extends WritableAtom<unknown, never[], unknown>>({
   children,
   atom,
   options,
 }: UseAtomProps<TAtom> &
   ChildrenRenderProps<
-    [Awaited<ExtractAtomValue<TAtom>>, (...args: ExtractAtomArgs<TAtom>) => ExtractAtomResult<TAtom>]
+    [Awaited<ExtractAtomValue<TAtom>>, TSetAtom<ExtractAtomArgs<TAtom>, ExtractAtomResult<TAtom>>]
   >): ReactNode
 
-/**
- * @experimental This is experimental feature.
- */
 export function Atom<TAtom extends JotaiAtom<unknown>>({
   children,
   atom,
   options,
 }: UseAtomProps<TAtom> & ChildrenRenderProps<[Awaited<ExtractAtomValue<TAtom>>, never]>): ReactNode
 
-/**
- * @experimental This is experimental feature.
- */
 export function Atom<TValue, TArgs extends unknown[], TResult>({
   children,
   atom,
   options,
-}: UseAtomProps<JotaiAtom<unknown>> & ChildrenRenderProps<any>): ReactNode {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+}: UseAtomProps<JotaiAtom<TValue> | WritableAtom<TValue, TArgs, TResult>> & ChildrenRenderProps<any>): ReactNode {
   return (
     <>{children([useAtomValue(atom, options), useSetAtom(atom as WritableAtom<TValue, TArgs, TResult>, options)])}</>
   )

--- a/packages/jotai/src/Atom.tsx
+++ b/packages/jotai/src/Atom.tsx
@@ -58,9 +58,14 @@ export function Atom<TValue, TArgs extends unknown[], TResult>({
   children,
   atom,
   options,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-}: UseAtomProps<JotaiAtom<TValue> | WritableAtom<TValue, TArgs, TResult>> & ChildrenRenderProps<any>): ReactNode {
+}: UseAtomProps<JotaiAtom<TValue> | WritableAtom<TValue, TArgs, TResult>> &
+  ChildrenRenderProps<ReturnType<typeof useAtom>>): ReactNode {
   return (
-    <>{children([useAtomValue(atom, options), useSetAtom(atom as WritableAtom<TValue, TArgs, TResult>, options)])}</>
+    <>
+      {children([
+        useAtomValue(atom, options),
+        useSetAtom(atom as WritableAtom<TValue, TArgs, TResult>, options) as never,
+      ])}
+    </>
   )
 }

--- a/packages/jotai/src/AtomValue.test-d.tsx
+++ b/packages/jotai/src/AtomValue.test-d.tsx
@@ -1,11 +1,46 @@
 import { atom, useAtomValue } from 'jotai'
+import { loadable } from 'jotai/utils'
 import type { ReactNode } from 'react'
 import { AtomValue } from './AtomValue'
 
-const asyncAtom = atom(() => Promise.resolve('string'))
+const countAtom = atom(0)
+const readOnlyCountAtom = atom((get) => get(countAtom))
+const writeOnlyCountAtom = atom(null, (get, set) => set(countAtom, get(countAtom) + 1))
+const asyncAtom = atom(async () => Promise.resolve('string'))
+const asyncIncrementAtom = atom(null, async (get, set) => {
+  set(countAtom, get(countAtom) + 1)
+})
+const loadableAtom = loadable(asyncAtom)
 
 describe('<AtomValue/>', () => {
   it('type check', () => {
+    ;() => (
+      <AtomValue atom={countAtom}>
+        {(value) => {
+          const valueOfJotai = useAtomValue(countAtom)
+          expectTypeOf(value).toEqualTypeOf<typeof valueOfJotai>()
+          return <></>
+        }}
+      </AtomValue>
+    )
+    ;() => (
+      <AtomValue atom={readOnlyCountAtom}>
+        {(value) => {
+          const valueOfJotai = useAtomValue(readOnlyCountAtom)
+          expectTypeOf(value).toEqualTypeOf<typeof valueOfJotai>()
+          return <></>
+        }}
+      </AtomValue>
+    )
+    ;() => (
+      <AtomValue atom={writeOnlyCountAtom}>
+        {(value) => {
+          const valueOfJotai = useAtomValue(writeOnlyCountAtom)
+          expectTypeOf(value).toEqualTypeOf<typeof valueOfJotai>()
+          return <></>
+        }}
+      </AtomValue>
+    )
     ;() => (
       <AtomValue atom={asyncAtom}>
         {(value) => {
@@ -15,8 +50,36 @@ describe('<AtomValue/>', () => {
         }}
       </AtomValue>
     )
+    ;() => (
+      <AtomValue atom={asyncIncrementAtom}>
+        {(value) => {
+          const valueOfJotai = useAtomValue(asyncIncrementAtom)
+          expectTypeOf(value).toEqualTypeOf<typeof valueOfJotai>()
+          return <></>
+        }}
+      </AtomValue>
+    )
+    ;() => (
+      <AtomValue atom={loadableAtom}>
+        {(value) => {
+          const valueOfJotai = useAtomValue(loadableAtom)
+          expectTypeOf(value).toEqualTypeOf<typeof valueOfJotai>()
+          return <></>
+        }}
+      </AtomValue>
+    )
 
+    expectTypeOf(<AtomValue atom={countAtom}>{() => <></>}</AtomValue>).toEqualTypeOf<JSX.Element>()
+    expectTypeOf(<AtomValue atom={countAtom}>{() => <></>}</AtomValue>).not.toEqualTypeOf<ReactNode>()
+    expectTypeOf(<AtomValue atom={readOnlyCountAtom}>{() => <></>}</AtomValue>).toEqualTypeOf<JSX.Element>()
+    expectTypeOf(<AtomValue atom={readOnlyCountAtom}>{() => <></>}</AtomValue>).not.toEqualTypeOf<ReactNode>()
+    expectTypeOf(<AtomValue atom={writeOnlyCountAtom}>{() => <></>}</AtomValue>).toEqualTypeOf<JSX.Element>()
+    expectTypeOf(<AtomValue atom={writeOnlyCountAtom}>{() => <></>}</AtomValue>).not.toEqualTypeOf<ReactNode>()
     expectTypeOf(<AtomValue atom={asyncAtom}>{() => <></>}</AtomValue>).toEqualTypeOf<JSX.Element>()
     expectTypeOf(<AtomValue atom={asyncAtom}>{() => <></>}</AtomValue>).not.toEqualTypeOf<ReactNode>()
+    expectTypeOf(<AtomValue atom={asyncIncrementAtom}>{() => <></>}</AtomValue>).toEqualTypeOf<JSX.Element>()
+    expectTypeOf(<AtomValue atom={asyncIncrementAtom}>{() => <></>}</AtomValue>).not.toEqualTypeOf<ReactNode>()
+    expectTypeOf(<AtomValue atom={loadableAtom}>{() => <></>}</AtomValue>).toEqualTypeOf<JSX.Element>()
+    expectTypeOf(<AtomValue atom={loadableAtom}>{() => <></>}</AtomValue>).not.toEqualTypeOf<ReactNode>()
   })
 })

--- a/packages/jotai/src/AtomValue.tsx
+++ b/packages/jotai/src/AtomValue.tsx
@@ -3,12 +3,9 @@ import type { ChildrenRenderProps } from './utility-types'
 
 type UseAtomValueProps<TValue> = {
   atom: JotaiAtom<TValue>
-  options?: Parameters<typeof useAtomValue>[1] & { delay?: number }
+  options?: Parameters<typeof useAtomValue>[1]
 }
 
-/**
- * @experimental This is experimental feature.
- */
 export function AtomValue<TValue>({
   children,
   atom,

--- a/packages/jotai/src/AtomValue.tsx
+++ b/packages/jotai/src/AtomValue.tsx
@@ -1,8 +1,9 @@
-import { type Atom as JotaiAtom, useAtomValue } from 'jotai'
+import { type ExtractAtomValue, type Atom as JotaiAtom, useAtomValue } from 'jotai'
+import type { ReactNode } from 'react'
 import type { ChildrenRenderProps } from './utility-types'
 
-type UseAtomValueProps<TValue> = {
-  atom: JotaiAtom<TValue>
+type UseAtomValueProps<TAtom extends Parameters<typeof useAtomValue>[0]> = {
+  atom: TAtom
   options?: Parameters<typeof useAtomValue>[1]
 }
 
@@ -10,6 +11,18 @@ export function AtomValue<TValue>({
   children,
   atom,
   options,
-}: UseAtomValueProps<TValue> & ChildrenRenderProps<Awaited<TValue>>) {
+}: UseAtomValueProps<JotaiAtom<TValue>> & ChildrenRenderProps<Awaited<TValue>>): ReactNode
+
+export function AtomValue<TAtom extends JotaiAtom<unknown>>({
+  children,
+  atom,
+  options,
+}: UseAtomValueProps<TAtom> & ChildrenRenderProps<Awaited<ExtractAtomValue<TAtom>>>): ReactNode
+
+export function AtomValue<TValue>({
+  children,
+  atom,
+  options,
+}: UseAtomValueProps<JotaiAtom<TValue>> & ChildrenRenderProps<ReturnType<typeof useAtomValue>>): ReactNode {
   return <>{children(useAtomValue(atom, options))}</>
 }

--- a/packages/jotai/src/SetAtom.test-d.tsx
+++ b/packages/jotai/src/SetAtom.test-d.tsx
@@ -3,14 +3,36 @@ import type { ReactNode } from 'react'
 import { SetAtom } from './SetAtom'
 
 const countAtom = atom(0)
+const writeOnlyCountAtom = atom(null, (get, set) => set(countAtom, get(countAtom) + 1))
+const asyncIncrementAtom = atom(null, async (get, set) => {
+  set(countAtom, get(countAtom) + 1)
+})
 
 describe('<SetAtom/>', () => {
   it('type check', () => {
     ;() => (
       <SetAtom atom={countAtom}>
-        {(setCount) => {
-          const setCountOfJotai = useSetAtom(countAtom)
-          expectTypeOf(setCount).toEqualTypeOf<typeof setCountOfJotai>()
+        {(value) => {
+          const valueOfJotai = useSetAtom(countAtom)
+          expectTypeOf(value).toEqualTypeOf<typeof valueOfJotai>()
+          return <></>
+        }}
+      </SetAtom>
+    )
+    ;() => (
+      <SetAtom atom={writeOnlyCountAtom}>
+        {(value) => {
+          const valueOfJotai = useSetAtom(writeOnlyCountAtom)
+          expectTypeOf(value).toEqualTypeOf<typeof valueOfJotai>()
+          return <></>
+        }}
+      </SetAtom>
+    )
+    ;() => (
+      <SetAtom atom={asyncIncrementAtom}>
+        {(value) => {
+          const valueOfJotai = useSetAtom(asyncIncrementAtom)
+          expectTypeOf(value).toEqualTypeOf<typeof valueOfJotai>()
           return <></>
         }}
       </SetAtom>
@@ -18,5 +40,9 @@ describe('<SetAtom/>', () => {
 
     expectTypeOf(<SetAtom atom={countAtom}>{() => <></>}</SetAtom>).toEqualTypeOf<JSX.Element>()
     expectTypeOf(<SetAtom atom={countAtom}>{() => <></>}</SetAtom>).not.toEqualTypeOf<ReactNode>()
+    expectTypeOf(<SetAtom atom={writeOnlyCountAtom}>{() => <></>}</SetAtom>).toEqualTypeOf<JSX.Element>()
+    expectTypeOf(<SetAtom atom={writeOnlyCountAtom}>{() => <></>}</SetAtom>).not.toEqualTypeOf<ReactNode>()
+    expectTypeOf(<SetAtom atom={asyncIncrementAtom}>{() => <></>}</SetAtom>).toEqualTypeOf<JSX.Element>()
+    expectTypeOf(<SetAtom atom={asyncIncrementAtom}>{() => <></>}</SetAtom>).not.toEqualTypeOf<ReactNode>()
   })
 })

--- a/packages/jotai/src/SetAtom.tsx
+++ b/packages/jotai/src/SetAtom.tsx
@@ -6,9 +6,6 @@ type UseSetAtomProps<TValue, TArgs extends unknown[], TResult> = {
   options?: Parameters<typeof useSetAtom>[1]
 }
 
-/**
- * @experimental This is experimental feature.
- */
 export function SetAtom<TValue, TArgs extends unknown[], TResult>({
   children,
   atom,

--- a/packages/jotai/src/SetAtom.tsx
+++ b/packages/jotai/src/SetAtom.tsx
@@ -1,5 +1,5 @@
 import { type WritableAtom, useSetAtom } from 'jotai'
-import type { ChildrenRenderProps } from './utility-types'
+import type { ChildrenRenderProps, SetAtom as TSetAtom } from './utility-types'
 
 type UseSetAtomProps<TValue, TArgs extends unknown[], TResult> = {
   atom: WritableAtom<TValue, TArgs, TResult>
@@ -10,6 +10,6 @@ export function SetAtom<TValue, TArgs extends unknown[], TResult>({
   children,
   atom,
   options,
-}: UseSetAtomProps<TValue, TArgs, TResult> & ChildrenRenderProps<(...args: TArgs) => TResult>) {
+}: UseSetAtomProps<TValue, TArgs, TResult> & ChildrenRenderProps<TSetAtom<TArgs, TResult>>) {
   return <>{children(useSetAtom(atom, options))}</>
 }

--- a/packages/jotai/src/SetAtom.tsx
+++ b/packages/jotai/src/SetAtom.tsx
@@ -1,15 +1,26 @@
-import { type WritableAtom, useSetAtom } from 'jotai'
+import { type ExtractAtomArgs, type ExtractAtomResult, type WritableAtom, useSetAtom } from 'jotai'
+import type { ReactNode } from 'react'
 import type { ChildrenRenderProps, SetAtom as TSetAtom } from './utility-types'
 
-type UseSetAtomProps<TValue, TArgs extends unknown[], TResult> = {
-  atom: WritableAtom<TValue, TArgs, TResult>
+type UseSetAtomProps<TAtom> = {
+  atom: TAtom
   options?: Parameters<typeof useSetAtom>[1]
 }
+
+export function SetAtom<TValue, TArgs extends unknown[], TResult>({
+  atom,
+  options,
+}: UseSetAtomProps<WritableAtom<TValue, TArgs, TResult>> & ChildrenRenderProps<TSetAtom<TArgs, TResult>>): ReactNode
+
+export function SetAtom<TAtom extends WritableAtom<unknown, never[], unknown>>({
+  atom,
+  options,
+}: UseSetAtomProps<TAtom> & ChildrenRenderProps<TSetAtom<ExtractAtomArgs<TAtom>, ExtractAtomResult<TAtom>>>): ReactNode
 
 export function SetAtom<TValue, TArgs extends unknown[], TResult>({
   children,
   atom,
   options,
-}: UseSetAtomProps<TValue, TArgs, TResult> & ChildrenRenderProps<TSetAtom<TArgs, TResult>>) {
+}: UseSetAtomProps<WritableAtom<TValue, TArgs, TResult>> & ChildrenRenderProps<TSetAtom<TArgs, TResult>>): ReactNode {
   return <>{children(useSetAtom(atom, options))}</>
 }

--- a/packages/jotai/src/utility-types/ChildrenRenderProps.ts
+++ b/packages/jotai/src/utility-types/ChildrenRenderProps.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
 
-export interface ChildrenRenderProps<TValue> {
-  children: (value: TValue) => ReactNode
+export interface ChildrenRenderProps<TArgument> {
+  children: (arg: TArgument) => ReactNode
 }

--- a/packages/jotai/src/utility-types/SetAtom.ts
+++ b/packages/jotai/src/utility-types/SetAtom.ts
@@ -1,0 +1,1 @@
+export type SetAtom<TArgs extends unknown[], TResult> = (...args: TArgs) => TResult

--- a/packages/jotai/src/utility-types/index.ts
+++ b/packages/jotai/src/utility-types/index.ts
@@ -1,1 +1,2 @@
 export type { ChildrenRenderProps } from './ChildrenRenderProps'
+export type { SetAtom } from './SetAtom'


### PR DESCRIPTION
# Overview

The changes were not significant, so I included them in a single PR. If you think the PR title is inappropriate, please feel free to change it.

- Improve type inference for atom
  - Improved to ensure the same type inference as the original Jotai package.
- Add test cases
- Remove experimental tag
  - in suspensive.org docs
  - in jotai interface

I have tested in the local environment to ensure that it behaves the same as Jotai (across all features). Fortunately, it works well, and I believe it is production-ready, just like Jotai. 

With these improvements, I think the Jotai package is ready to be released as version `1.0.0`.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
