### PR TITLE
feat(react-query-4): export UnselectedQueryOptions, SelectedQueryOptions

### DIFF
--- a/.changeset/perfect-games-push.md
+++ b/.changeset/perfect-games-push.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react-query-4": patch
+---
+
+chore(react-query-4): update exports for query options

--- a/.changeset/perfect-games-push.md
+++ b/.changeset/perfect-games-push.md
@@ -2,4 +2,4 @@
 "@suspensive/react-query-4": patch
 ---
 
-chore(react-query-4): update exports for query options
+feat(react-query-4): export UnselectedQueryOptions, SelectedQueryOptions

--- a/.changeset/perfect-games-push.md
+++ b/.changeset/perfect-games-push.md
@@ -1,5 +1,5 @@
 ---
-"@suspensive/react-query-4": patch
+"@suspensive/react-query-4": minor
 ---
 
 feat(react-query-4): export UnselectedQueryOptions, SelectedQueryOptions

--- a/packages/react-query-4/src/index.ts
+++ b/packages/react-query-4/src/index.ts
@@ -1,5 +1,7 @@
 export { queryOptions } from './queryOptions'
+export type { SelectedQueryOptions, UnSelectedQueryOptions } from './queryOptions'
 export { infiniteQueryOptions } from './infiniteQueryOptions'
+export type { SelectedInfiniteOptions, UnSelectedInfiniteOptions } from './infiniteQueryOptions'
 export { useSuspenseQuery } from './useSuspenseQuery'
 export type { UseSuspenseQueryOptions, UseSuspenseQueryResult } from './useSuspenseQuery'
 export { useSuspenseQueries } from './useSuspenseQueries'

--- a/packages/react-query-4/src/infiniteQueryOptions.ts
+++ b/packages/react-query-4/src/infiniteQueryOptions.ts
@@ -1,7 +1,7 @@
 import type { OmitKeyof, RequiredKeyof } from '@suspensive/utils'
 import type { InfiniteData, QueryKey, UseInfiniteQueryOptions } from '@tanstack/react-query'
 
-type SelectedInfiniteOptions<
+export type SelectedInfiniteOptions<
   TQueryFnData,
   TError = unknown,
   TData = InfiniteData<TQueryFnData>,
@@ -26,7 +26,7 @@ type SelectedInfiniteOptions<
   select: (data: InfiniteData<TQueryFnData>) => InfiniteData<TData>
 }
 
-type UnSelectedInfiniteOptions<
+export type UnSelectedInfiniteOptions<
   TQueryFnData,
   TError = unknown,
   TData = InfiniteData<TQueryFnData>,

--- a/packages/react-query-4/src/queryOptions.ts
+++ b/packages/react-query-4/src/queryOptions.ts
@@ -1,7 +1,7 @@
 import type { OmitKeyof, RequiredKeyof } from '@suspensive/utils'
 import type { QueryKey, UseQueryOptions } from '@tanstack/react-query'
 
-type SelectedQueryOptions<
+export type SelectedQueryOptions<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,
@@ -28,7 +28,7 @@ type SelectedQueryOptions<
   select: (data: TQueryFnData) => TData
 }
 
-type UnSelectedQueryOptions<
+export type UnSelectedQueryOptions<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->
Add exports for queryOptions return type
Fix ts error such as `The inferred type of "X" cannot be named without a reference to "Y". This is likely not portable. A type annotation is necessary.` when emitting d.ts file

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
