### PR TITLE
refactor(react): update `usePreservedCallback` signature

### DIFF
--- a/.changeset/tricky-chicken-provide.md
+++ b/.changeset/tricky-chicken-provide.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react": patch
+---
+
+refactor(react): update `usePreservedCallback` signature

--- a/packages/react/src/hooks/usePreservedCallback.test-d.ts
+++ b/packages/react/src/hooks/usePreservedCallback.test-d.ts
@@ -16,13 +16,7 @@ describe('usePreservedCallback', () => {
     ).toEqualTypeOf<(a: number, b: string) => void>()
 
     expectTypeOf(
-      usePreservedCallback((a: number, b: string) => {
-        if (a > 0) {
-          return b
-        }
-
-        return a
-      })
+      usePreservedCallback((a: number, b: string) => Math.random() > 0.5 ? a : b)
     ).toEqualTypeOf<(a: number, b: string) => number | string>()
     expectTypeOf(
       usePreservedCallback((a) => {

--- a/packages/react/src/hooks/usePreservedCallback.test-d.ts
+++ b/packages/react/src/hooks/usePreservedCallback.test-d.ts
@@ -1,0 +1,33 @@
+import { usePreservedCallback } from './usePreservedCallback'
+
+describe('usePreservedCallback', () => {
+  it('type check', () => {
+    expectTypeOf(
+      usePreservedCallback(() => {
+        /* empty */
+      })
+    ).toEqualTypeOf<() => void>()
+
+    expectTypeOf(
+      usePreservedCallback((a: number, b: string) => {
+        a
+        b
+      })
+    ).toEqualTypeOf<(a: number, b: string) => void>()
+
+    expectTypeOf(
+      usePreservedCallback((a: number, b: string) => {
+        if (a > 0) {
+          return b
+        }
+
+        return a
+      })
+    ).toEqualTypeOf<(a: number, b: string) => number | string>()
+    expectTypeOf(
+      usePreservedCallback((a) => {
+        a
+      })
+    ).toEqualTypeOf<(a: any) => void>()
+  })
+})

--- a/packages/react/src/hooks/usePreservedCallback.test-d.ts
+++ b/packages/react/src/hooks/usePreservedCallback.test-d.ts
@@ -15,9 +15,9 @@ describe('usePreservedCallback', () => {
       })
     ).toEqualTypeOf<(a: number, b: string) => void>()
 
-    expectTypeOf(
-      usePreservedCallback((a: number, b: string) => Math.random() > 0.5 ? a : b)
-    ).toEqualTypeOf<(a: number, b: string) => number | string>()
+    expectTypeOf(usePreservedCallback((a: number, b: string) => (Math.random() > 0.5 ? a : b))).toEqualTypeOf<
+      (a: number, b: string) => number | string
+    >()
     expectTypeOf(
       usePreservedCallback((a) => {
         a

--- a/packages/react/src/hooks/usePreservedCallback.ts
+++ b/packages/react/src/hooks/usePreservedCallback.ts
@@ -1,14 +1,14 @@
 import { useCallback, useRef } from 'react'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
-export const usePreservedCallback = <T extends (...args: unknown[]) => unknown>(callback: T) => {
+export const usePreservedCallback = <T extends (...args: any[]) => unknown>(callback: T): T => {
   const callbackRef = useRef<T>(callback)
 
   useIsomorphicLayoutEffect(() => {
     callbackRef.current = callback
   }, [callback])
 
-  return useCallback((...args: unknown[]) => {
+  return useCallback((...args: Parameters<T>) => {
     return callbackRef.current(...args)
   }, []) as T
 }


### PR DESCRIPTION
# Overview

Since ₩usePreservedCallback₩ needs to accept functions of all forms, due to contravariance, it’s appropriate to set the function parameter to the lowest possible type(`never`).

<img width="431" alt="Screenshot 2024-10-16 at 11 50 57 AM" src="https://github.com/user-attachments/assets/180397a8-c12a-4e80-ad86-d78e8a13dc0b">

However, previously it was set to `unknown`, so when you pass in a function with specified parameter types, TypeScript throws an error.

<img width="373" alt="Screenshot 2024-10-16 at 11 51 16 AM" src="https://github.com/user-attachments/assets/577ad0cd-b457-49c5-bbb0-c28b39b428e5">

Initially, I changed it to `never`, but since `never` has a problem in situations like the one above with `implicit any`. Because `implicit any` was inferred as `never`.

Therefore, in the end, I set it to the `any` type.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
