### PR TITLE
fix(react): change `defineSuspense` function signature

### DIFF
--- a/.changeset/eleven-laws-appear.md
+++ b/.changeset/eleven-laws-appear.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react": patch
+---
+
+fix(react): change `defineSuspense` function signature

--- a/packages/react/src/utils/defineSuspense.test-d.ts
+++ b/packages/react/src/utils/defineSuspense.test-d.ts
@@ -14,11 +14,11 @@ describe('defineSuspense', () => {
     expectTypeOf(defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: true })).toEqualTypeOf<
       typeof SuspenseClientOnly
     >()
-    expectTypeOf(defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: false })).toEqualTypeOf<
-      typeof SuspenseClientOnly
-    >()
     expectTypeOf(defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: true })).toEqualTypeOf<
       typeof SuspenseClientOnly
+    >()
+    expectTypeOf(defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: false })).toEqualTypeOf<
+      typeof Suspense
     >()
     expectTypeOf(defineSuspense({ defaultPropsClientOnly: false, componentPropsClientOnly: false })).toEqualTypeOf<
       typeof Suspense

--- a/packages/react/src/utils/defineSuspense.test-d.ts
+++ b/packages/react/src/utils/defineSuspense.test-d.ts
@@ -5,10 +5,10 @@ describe('defineSuspense', () => {
   it('type check', () => {
     expectTypeOf(defineSuspense({ componentPropsClientOnly: true })).toEqualTypeOf<typeof SuspenseClientOnly>()
     expectTypeOf(defineSuspense({ defaultPropsClientOnly: true })).toEqualTypeOf<typeof SuspenseClientOnly>()
-    expectTypeOf(defineSuspense({ componentPropsClientOnly: true, defaultPropsClientOnly: undefined })).toEqualTypeOf<
+    expectTypeOf(defineSuspense({ defaultPropsClientOnly: undefined, componentPropsClientOnly: true })).toEqualTypeOf<
       typeof SuspenseClientOnly
     >()
-    expectTypeOf(defineSuspense({ componentPropsClientOnly: undefined, defaultPropsClientOnly: true })).toEqualTypeOf<
+    expectTypeOf(defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: undefined })).toEqualTypeOf<
       typeof SuspenseClientOnly
     >()
     expectTypeOf(defineSuspense({ defaultPropsClientOnly: true, componentPropsClientOnly: true })).toEqualTypeOf<

--- a/packages/react/src/utils/defineSuspense.tsx
+++ b/packages/react/src/utils/defineSuspense.tsx
@@ -18,10 +18,12 @@ export function defineSuspense(
         defaultPropsClientOnly: true
       }
 ): typeof SuspenseClientOnly
+
 export function defineSuspense(options: {
   componentPropsClientOnly?: boolean
   defaultPropsClientOnly?: boolean
 }): typeof Suspense
+
 export function defineSuspense({
   defaultPropsClientOnly,
   componentPropsClientOnly,

--- a/packages/react/src/utils/defineSuspense.tsx
+++ b/packages/react/src/utils/defineSuspense.tsx
@@ -7,35 +7,21 @@ export const SuspenseClientOnly = (props: SuspenseProps) => (
   </ClientOnly>
 )
 
-/* eslint-disable @typescript-eslint/unified-signatures */
-export function defineSuspense(options: { componentPropsClientOnly: true }): typeof SuspenseClientOnly
-export function defineSuspense(options: { defaultPropsClientOnly: true }): typeof SuspenseClientOnly
+export function defineSuspense(
+  options:
+    | {
+        componentPropsClientOnly: true
+        defaultPropsClientOnly?: boolean
+      }
+    | {
+        componentPropsClientOnly?: undefined
+        defaultPropsClientOnly: true
+      }
+): typeof SuspenseClientOnly
 export function defineSuspense(options: {
-  componentPropsClientOnly: true
-  defaultPropsClientOnly: undefined
-}): typeof SuspenseClientOnly
-export function defineSuspense(options: {
-  componentPropsClientOnly: undefined
-  defaultPropsClientOnly: true
-}): typeof SuspenseClientOnly
-export function defineSuspense(options: {
-  componentPropsClientOnly: true
-  defaultPropsClientOnly: true
-}): typeof SuspenseClientOnly
-export function defineSuspense(options: {
-  componentPropsClientOnly: true
-  defaultPropsClientOnly: false
-}): typeof SuspenseClientOnly
-export function defineSuspense(options: {
-  componentPropsClientOnly: false
-  defaultPropsClientOnly: true
-}): typeof SuspenseClientOnly
-export function defineSuspense(options: {
-  componentPropsClientOnly: false
-  defaultPropsClientOnly: false
+  componentPropsClientOnly?: boolean
+  defaultPropsClientOnly?: boolean
 }): typeof Suspense
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export function defineSuspense(options: {}): typeof Suspense
 export function defineSuspense({
   defaultPropsClientOnly,
   componentPropsClientOnly,


### PR DESCRIPTION
# Overview

I made modifications because, when `componentPropsClientOnly` is set to `false`, it returns `Suspense`, but the overloaded function signature indicated that it returns `SuspenseClientOnly`.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
