### PR TITLE
chore(.github/actions/pnpm-setup-node): remove version field in with of pnpm/action-setup

### DIFF
--- a/.github/actions/pnpm-setup-node/action.yml
+++ b/.github/actions/pnpm-setup-node/action.yml
@@ -4,10 +4,8 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@v4
-      with:
-        version: 9.12.3
     - uses: actions/setup-node@v4
       with:
-        cache: "pnpm"
-        cache-dependency-path: "pnpm-lock.yaml"
-        node-version-file: ".nvmrc"
+        cache: 'pnpm'
+        cache-dependency-path: 'pnpm-lock.yaml'
+        node-version-file: '.nvmrc'


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

removed the version specified in the with field of pnpm/action-setup. [when the pnpm version is already defined in the packageManager field of package.json, pnpm/action-setup can automatically recognize and use it](https://github.com/pnpm/action-setup/tree/v4/?tab=readme-ov-file#version). duplicating the version setting adds unnecessary complexity and increases maintenance overhead without added benefit.

by relying on the version specified in packageManager, this change simplifies the configuration and ensures consistency.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
