### PR TITLE
docs(suspensive.org): correct queryOptions to infiniteQueryOptions in SuspenseInfiniteQuery example

### DIFF
--- a/docs/suspensive.org/src/pages/en/docs/react-query/SuspenseInfiniteQuery.mdx
+++ b/docs/suspensive.org/src/pages/en/docs/react-query/SuspenseInfiniteQuery.mdx
@@ -110,13 +110,17 @@ export const PostListItem = (props: Post) => {
 ```
 
 ```tsx queries.ts
-import { queryOptions } from '@suspensive/react-query'
+import { infiniteQueryOptions } from '@suspensive/react-query'
 import { getInfinitePosts } from './api'
 
 export const postsInfiniteQueryOptions = () =>
-  queryOptions({
+  infiniteQueryOptions({
     queryKey: ['posts'],
     queryFn: ({ pageParam = 1 }) => getInfinitePosts(pageParam),
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.skip + lastPage.limit < lastPage.total
+        ? allPages.length + 1
+        : undefined,
   })
 ```
 

--- a/docs/suspensive.org/src/pages/ko/docs/react-query/SuspenseInfiniteQuery.mdx
+++ b/docs/suspensive.org/src/pages/ko/docs/react-query/SuspenseInfiniteQuery.mdx
@@ -110,13 +110,17 @@ export const PostListItem = (props: Post) => {
 ```
 
 ```tsx queries.ts
-import { queryOptions } from '@suspensive/react-query'
+import { infiniteQueryOptions } from '@suspensive/react-query'
 import { getInfinitePosts } from './api'
 
 export const postsInfiniteQueryOptions = () =>
-  queryOptions({
+  infiniteQueryOptions({
     queryKey: ['posts'],
     queryFn: ({ pageParam = 1 }) => getInfinitePosts(pageParam),
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.skip + lastPage.limit < lastPage.total
+        ? allPages.length + 1
+        : undefined,
   })
 ```
 


### PR DESCRIPTION
# Overview

```tsx queries.ts
import { queryOptions } from '@suspensive/react-query'
import { getInfinitePosts } from './api'

export const postsInfiniteQueryOptions = () =>
  queryOptions({
    queryKey: ['posts'],
    queryFn: ({ pageParam = 1 }) => getInfinitePosts(pageParam),
  })
```

The `queries.ts` logic in the [`SuspenseInfiniteQuery`](https://suspensive.org/ko/docs/react-query/SuspenseInfiniteQuery) component example on suspensive.org was using inappropriate `queryOptions`. This PR updates the example to use `infiniteQueryOptions` instead for better accuracy and relevance.

I referred to the `getNextPageParam` section in the [useSuspenseInfiniteQuery](https://suspensive.org/ko/docs/react-query/useSuspenseInfiniteQuery) part of this document.

```tsx queries.ts
import { infiniteQueryOptions } from '@suspensive/react-query'
import { getInfinitePosts } from './api'

export const postsInfiniteQueryOptions = () =>
  infiniteQueryOptions({
    queryKey: ['posts'],
    queryFn: ({ pageParam = 1 }) => getInfinitePosts(pageParam),
    getNextPageParam: (lastPage, allPages) =>
      lastPage.skip + lastPage.limit < lastPage.total
        ? allPages.length + 1
        : undefined,
  })
```


## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
