### PR TITLE
fix(react-query): remove peerDeps error when installing @suspensive/react-query

### DIFF
--- a/.changeset/chilly-mugs-press.md
+++ b/.changeset/chilly-mugs-press.md
@@ -1,0 +1,7 @@
+---
+'@suspensive/react-query-4': patch
+'@suspensive/react-query-5': patch
+'@suspensive/react-query': patch
+---
+
+remove peerDeps error

--- a/packages/react-query-4/package.json
+++ b/packages/react-query-4/package.json
@@ -58,13 +58,8 @@
     "react": "catalog:react19"
   },
   "peerDependencies": {
-    "@tanstack/react-query": "^4",
+    "@tanstack/react-query": "*",
     "react": "^18 || ^19"
-  },
-  "peerDependenciesMeta": {
-    "@tanstack/react-query": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-query-5/package.json
+++ b/packages/react-query-5/package.json
@@ -58,13 +58,8 @@
     "react": "catalog:react19"
   },
   "peerDependencies": {
-    "@tanstack/react-query": "^5",
+    "@tanstack/react-query": "*",
     "react": "^18 || ^19"
-  },
-  "peerDependenciesMeta": {
-    "@tanstack/react-query": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

remove below peerDeps error
We want to premote @suspensive/react-query & prevent installing @suspensive/react-query-*.  

```shell
➤ YN0000: ┌ Post-resolution validation
➤ YN0060: │ @tanstack/react-query is listed by your project with version 4.0.10 (p8ab5e), which doesn't satisfy what @suspensive/react-query-5 (via @suspensive/react-query) and other dependencies request (but they have non-overlapping ranges!).
```

And I want to prevent one way to alias like below

```json
{
  "dependencies": {
    "@suspensive/react": "^2.18.12",
    "@suspensive/react-query": "npm:@suspensive/react-query-4@^2.18.12",
  }
}
```

We want to make users just use like below

```json
{
  "dependencies": {
    "@suspensive/react": "^3.0.0",
    "@suspensive/react-query": "^3.0.0",
  }
}
```

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
