### PR TITLE
fix: resolve issues in JSR publish action

### DIFF
--- a/.changeset/empty-colts-yell.md
+++ b/.changeset/empty-colts-yell.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react-query": patch
+---
+
+fix: resolve issues in JSR publish action

--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -11,8 +11,8 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' || 
       (github.event_name == 'pull_request' && 
-       github.event.pull_request.merged == true && 
-       contains(github.event.pull_request.title, 'chore: version packages'))
+      github.event.pull_request.merged == true && 
+      contains(github.event.pull_request.title, 'chore: version packages'))
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/packages/react-query/jsr.json
+++ b/packages/react-query/jsr.json
@@ -3,6 +3,10 @@
   "name": "@suspensive/react-query",
   "version": "3.0.0-next.6",
   "exports": "./src/index.ts",
+  "imports": {
+    "@suspensive/react-query-4": "../react-query-4/src/index.ts",
+    "@suspensive/react": "../react/src/index.ts"
+  },
   "publish": {
     "include": ["LICENSE", "package.json", "src/**/*"],
     "exclude": ["src/**/*.spec*"]

--- a/scripts/jsr-utils.ts
+++ b/scripts/jsr-utils.ts
@@ -56,6 +56,9 @@ export function writeResultsToLog(results: JsrResult[], isDryRun: boolean): void
       .forEach((result) => {
         console.log(`FAILED: ${result.packageName}`)
       })
+
+    console.error('\nJSR command failed for one or more packages. Exiting with error code 1.')
+    process.exit(1)
   } else {
     console.log('All packages processed successfully!')
   }

--- a/scripts/jsr-utils.ts
+++ b/scripts/jsr-utils.ts
@@ -19,21 +19,21 @@ export async function executeJsrCommand(packagePath: string, isDryRun: boolean):
   console.log(`\n===== ${isDryRun ? 'Testing' : 'Publishing'} JSR in ${packageName} =====`)
 
   try {
-    const args = ['jsr', 'publish']
-
+    const args = ['dlx', 'jsr', 'publish']
     if (isDryRun) {
       args.push('--dry-run', '--allow-slow-types', '--allow-dirty')
     } else {
       args.push('--allow-slow-types')
     }
 
-    await execa('npx', args, {
+    await execa('pnpm', args, {
       cwd: packageDir,
       stdio: 'inherit',
     })
 
     return { packageName, success: true }
   } catch (error) {
+    console.error(`Error in ${packageName}:`, error.message || error)
     return { packageName, success: false }
   }
 }


### PR DESCRIPTION
# Overview

Related with https://github.com/toss/suspensive/pull/1475

- Fixed issues in the JSR publish action.
- Replaced `npx jsr publish` with `pnpm dlx jsr publish` for better compatibility.
- Added new import paths in jsr.json to properly map package name-style imports to actual paths in JSR, ensuring correct resolution for `@suspensive/react-query`.
- Ensured the CI stops if any JSR publish attempt fails by exiting with an error code.


<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
