### PR TITLE
fix: configure JSR publishing with GitHub Actions OIDC

### DIFF
--- a/.changeset/full-moments-run.md
+++ b/.changeset/full-moments-run.md
@@ -1,0 +1,5 @@
+---
+'@suspensive/react': patch
+---
+
+fix: configure JSR publishing with GitHub Actions OIDC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm-setup-node


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Configures OIDC authentication for tokenless publishing in GitHub Actions.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
