### PR TITLE
chore: Improve JSR imports sync with consistent dependency formatting

### DIFF
--- a/.changeset/kind-waves-build.md
+++ b/.changeset/kind-waves-build.md
@@ -1,0 +1,13 @@
+---
+'@suspensive/react-query-4': patch
+'@suspensive/react-query-5': patch
+'@suspensive/eslint-config': patch
+'@suspensive/react-native': patch
+'@suspensive/react-query': patch
+'@suspensive/react-dom': patch
+'@suspensive/codemods': patch
+'@suspensive/jotai': patch
+'@suspensive/react': patch
+---
+
+chore: improve JSR imports sync with consistent dependency formatting

--- a/packages/jotai/jsr.json
+++ b/packages/jotai/jsr.json
@@ -3,6 +3,10 @@
   "name": "@suspensive/jotai",
   "version": "3.0.0-next.14",
   "exports": "./src/index.ts",
+  "imports": {
+    "jotai": "npm:jotai@^2",
+    "react": "npm:react@^19"
+  },
   "publish": {
     "include": ["LICENSE", "package.json", "src/**/*"],
     "exclude": ["src/**/*.test*"]

--- a/packages/react-dom/jsr.json
+++ b/packages/react-dom/jsr.json
@@ -3,6 +3,10 @@
   "name": "@suspensive/react-dom",
   "version": "3.0.0-next.14",
   "exports": "./src/index.ts",
+  "imports": {
+    "react": "npm:react@^19",
+    "react-dom": "npm:react-dom@^19"
+  },
   "publish": {
     "include": ["LICENSE", "package.json", "src/**/*"],
     "exclude": ["src/**/*.test*", "src/**/*.spec*", "test-utils/index.tsx"]

--- a/packages/react-native/jsr.json
+++ b/packages/react-native/jsr.json
@@ -3,6 +3,10 @@
   "name": "@suspensive/react-native",
   "version": "0.0.18-next.0",
   "exports": "./src/index.ts",
+  "imports": {
+    "react": "npm:react@^19",
+    "react-native": "npm:react-native@^0.76.1"
+  },
   "publish": {
     "include": ["LICENSE", "package.json", "src/**/*"],
     "exclude": ["src/**/*.spec*"]

--- a/packages/react-query-4/jsr.json
+++ b/packages/react-query-4/jsr.json
@@ -3,6 +3,10 @@
   "name": "@suspensive/react-query-4",
   "version": "3.0.0-next.14",
   "exports": "./src/index.ts",
+  "imports": {
+    "@tanstack/react-query": "npm:@tanstack/react-query@latest",
+    "react": "npm:react@^19"
+  },
   "publish": {
     "include": ["LICENSE", "package.json", "src/**/*"],
     "exclude": ["src/**/*.test*", "src/**/*.spec*", "src/test-utils"]

--- a/packages/react-query-5/jsr.json
+++ b/packages/react-query-5/jsr.json
@@ -3,6 +3,10 @@
   "name": "@suspensive/react-query-5",
   "version": "3.0.0-next.14",
   "exports": "./src/index.ts",
+  "imports": {
+    "@tanstack/react-query": "npm:@tanstack/react-query@latest",
+    "react": "npm:react@^19"
+  },
   "publish": {
     "include": ["LICENSE", "package.json", "src/**/*"],
     "exclude": ["src/**/*.test*", "src/**/*.spec*", "src/test-utils"]

--- a/packages/react-query/jsr.json
+++ b/packages/react-query/jsr.json
@@ -4,8 +4,13 @@
   "version": "3.0.0-next.14",
   "exports": "./src/index.ts",
   "imports": {
-    "@suspensive/react-query-4": "../react-query-4/src/index.ts",
-    "@suspensive/react": "../react/src/index.ts"
+    "@commander-js/extra-typings": "npm:@commander-js/extra-typings@^13.0.0",
+    "@suspensive/react-query-4": "jsr:@suspensive/react-query-4@^3.0.0-next.14",
+    "@suspensive/react-query-5": "jsr:@suspensive/react-query-5@^3.0.0-next.14",
+    "cli-table3": "npm:cli-table3@^0.6.5",
+    "commander": "npm:commander@^13.0.0",
+    "@tanstack/react-query": "npm:@tanstack/react-query@^5",
+    "react": "npm:react@^19"
   },
   "publish": {
     "include": ["LICENSE", "package.json", "src/**/*"],

--- a/packages/react/jsr.json
+++ b/packages/react/jsr.json
@@ -4,7 +4,7 @@
   "version": "3.0.0-next.14",
   "exports": "./src/index.ts",
   "imports": {
-    "react": "npm:react@^19.0.0"
+    "react": "npm:react@^19"
   },
   "publish": {
     "include": ["LICENSE", "package.json", "src/**/*"],

--- a/scripts/jsr-sync-versions.ts
+++ b/scripts/jsr-sync-versions.ts
@@ -8,7 +8,86 @@ const __dirname = path.dirname(__filename)
 const rootDir = path.resolve(__dirname, '..')
 const packagesDir = path.join(rootDir, 'packages')
 
-async function syncJsrVersions() {
+const SUSPENSIVE_SCOPE = '@suspensive'
+
+function convertToJsrCompatibleVersion(version: string): string {
+  if (version.includes('||')) {
+    const versions = version.split('||')
+    return versions[versions.length - 1].trim()
+  }
+
+  if (version === '*') {
+    return 'latest'
+  }
+
+  return version
+}
+
+function getPackageDirFromName(name: string): string {
+  if (name.startsWith(SUSPENSIVE_SCOPE)) {
+    return name.substring(SUSPENSIVE_SCOPE.length)
+  }
+  return name
+}
+
+function getLatestPackageVersion(packageName: string): string | null {
+  const dirName = getPackageDirFromName(packageName)
+  const packagePath = path.join(packagesDir, dirName, '/package.json')
+
+  if (!fs.existsSync(packagePath)) {
+    return null
+  }
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'))
+    return packageJson.version
+  } catch (error) {
+    console.error(`Error reading package.json for ${packageName}: ${error}`)
+    return null
+  }
+}
+
+function convertWorkspaceDependency(name: string, version: string): string {
+  if (!version.startsWith('workspace:')) {
+    const jsrCompatibleVersion = convertToJsrCompatibleVersion(version)
+    return `npm:${name}@${jsrCompatibleVersion}`
+  }
+
+  const packageName = name.startsWith('@') ? name : `${SUSPENSIVE_SCOPE}/${name}`
+  const versionPart = version.substring('workspace:'.length)
+
+  if (versionPart === '*') {
+    const latestVersion = getLatestPackageVersion(packageName)
+    if (latestVersion) {
+      return `jsr:${packageName}@${latestVersion}`
+    }
+    return `jsr:${packageName}`
+  }
+
+  return `jsr:${packageName}@${versionPart}`
+}
+
+function updateImports(imports: Record<string, string>, dependencies?: Record<string, string>): boolean {
+  if (dependencies == null) {
+    return false
+  }
+
+  let updated = false
+
+  for (const [name, version] of Object.entries(dependencies)) {
+    const importKey = name
+    const importValue = convertWorkspaceDependency(name, version)
+
+    if (imports[importKey] != null || imports[importKey] !== importValue) {
+      imports[importKey] = importValue
+      updated = true
+    }
+  }
+
+  return updated
+}
+
+async function syncJsrVersions(): Promise<void> {
   const packageDirs = fs.readdirSync(packagesDir)
 
   for (const dir of packageDirs) {
@@ -16,33 +95,50 @@ async function syncJsrVersions() {
     const packageJsonPath = path.join(packagePath, 'package.json')
     const jsrJsonPath = path.join(packagePath, 'jsr.json')
 
-    if (fs.existsSync(packageJsonPath) && fs.existsSync(jsrJsonPath)) {
-      try {
-        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
-        if (packageJson.private) {
-          continue
-        }
+    if (!fs.existsSync(packageJsonPath) || !fs.existsSync(jsrJsonPath)) {
+      continue
+    }
 
-        const jsrJson = JSON.parse(fs.readFileSync(jsrJsonPath, 'utf8'))
-
-        if (jsrJson.version !== packageJson.version) {
-          console.log(`Updating ${packageJson.name} JSR version from ${jsrJson.version} to ${packageJson.version}`)
-          jsrJson.version = packageJson.version
-
-          fs.writeFileSync(jsrJsonPath, JSON.stringify(jsrJson, null, 2) + '\n')
-
-          await execa('npx', ['prettier', '--write', jsrJsonPath], {
-            cwd: rootDir,
-            stdio: 'inherit',
-          })
-        }
-      } catch (error) {
-        console.error(`Error processing ${dir}: ${error instanceof Error ? error.message : String(error)}`)
+    try {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+      if (packageJson.private) {
+        continue
       }
+
+      const jsrJson = JSON.parse(fs.readFileSync(jsrJsonPath, 'utf8'))
+      let isUpdated = false
+
+      if (jsrJson.version !== packageJson.version) {
+        jsrJson.version = packageJson.version
+        isUpdated = true
+      }
+
+      const imports = jsrJson.imports || {}
+
+      const importsUpdated = updateImports(imports, {
+        ...(packageJson.dependencies || {}),
+        ...(packageJson.peerDependencies || {}),
+      })
+
+      if (importsUpdated) {
+        jsrJson.imports = imports
+        isUpdated = true
+      }
+
+      if (isUpdated) {
+        fs.writeFileSync(jsrJsonPath, JSON.stringify(jsrJson, null, 2) + '\n')
+
+        await execa('npx', ['prettier', '--write', jsrJsonPath], {
+          cwd: rootDir,
+          stdio: 'inherit',
+        })
+      }
+    } catch (error) {
+      console.error(`Error processing ${dir}: ${error instanceof Error ? error.message : String(error)}`)
     }
   }
 
-  console.log('JSR version sync completed')
+  console.log('JSR version and imports sync completed')
 }
 
 syncJsrVersions().catch((error) => {


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Enhanced JSR synchronization script to optimize dependency management and applied consistent formatting to all package jsr.json files.

Additionally, we need to add CI publishing permissions for all `@suspensive` packages on JSR. Currently, only `@suspensive/react` has CI publishing enabled. As mentioned in https://github.com/toss/suspensive/pull/1485#issuecomment-2733341949, we need to link the remaining packages under the 'Publish from CI' section on https://jsr.io/@suspensive.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
