### PR TITLE
refactor(suspensive.org): use direct type import for ReactNode

### DIFF
--- a/docs/suspensive.org/src/components/HomePage.tsx
+++ b/docs/suspensive.org/src/components/HomePage.tsx
@@ -4,7 +4,7 @@ import { ClientOnly } from '@suspensive/react'
 import { motion } from 'motion/react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useEffect, useRef } from 'react'
+import { type ReactNode, useEffect, useRef } from 'react'
 import { NpmInstallCopyButton } from './NpmInstallCopyButton'
 
 const CodeBlockClassName = 'nextra-code'
@@ -27,7 +27,7 @@ export const HomePage = ({
   buttonText: string
   items: { title: string; desc: string }[]
   version: number
-  children?: React.ReactNode
+  children?: ReactNode
 }) => {
   return (
     <>


### PR DESCRIPTION
# Overview

- Replaced `React.ReactNode` with a direct type import: `import { type ReactNode } from 'react'`

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
