### PR TITLE
fix(docs): update `metadataBase` to suspensive.org to fix relative metadata URL issues

### DIFF
--- a/docs/suspensive.org/src/app/[lang]/layout.tsx
+++ b/docs/suspensive.org/src/app/[lang]/layout.tsx
@@ -25,7 +25,7 @@ export const metadata = {
     default: 'Suspensive',
   },
   description: 'All in one for React Suspense',
-  metadataBase: new URL('https://swr.vercel.app'),
+  metadataBase: new URL('https://suspensive.org'),
   openGraph: { images: '/img/banner.png' },
   icons: '/img/favicon.ico',
 } satisfies Metadata


### PR DESCRIPTION
# Overview
The `metadataBase` field in the docs' metadata configuration defines the base domain used to resolve relative URLs into absolute ones.

Currently, it is set to a domain that differs from the actual deployment domain (`suspensive.org`). As a result, previews using relative metadata URLs fail to load correctly.

This PR updates the `metadataBase` to `https://suspensive.org` to ensure proper resolution of relative URLs and fix the preview issue.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
