### PR TITLE
fix(suspensive.org): prevent horizontal scroll on mobile by adjusting margins

### DIFF
--- a/docs/suspensive.org/src/components/HomePage.tsx
+++ b/docs/suspensive.org/src/components/HomePage.tsx
@@ -46,7 +46,7 @@ export const HomePage = ({
       <motion.section
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        className="-mx-4 -mt-4 bg-[url('/img/homepage_background.svg')] bg-cover bg-center bg-no-repeat px-10 pb-20 md:-mx-12"
+        className="-mx-4 -mt-4 bg-[url('/img/homepage_background.svg')] bg-cover bg-center bg-no-repeat pb-20 md:-mx-12"
       >
         <div className="flex flex-col items-center justify-center gap-8 text-center">
           <div className="flex flex-col items-center">

--- a/docs/suspensive.org/src/components/HomePage.tsx
+++ b/docs/suspensive.org/src/components/HomePage.tsx
@@ -46,7 +46,7 @@ export const HomePage = ({
       <motion.section
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        className="-mx-12 -mt-4 bg-[url('/img/homepage_background.svg')] bg-cover bg-center bg-no-repeat px-10 pb-20"
+        className="-mx-4 -mt-4 bg-[url('/img/homepage_background.svg')] bg-cover bg-center bg-no-repeat px-10 pb-20 md:-mx-12"
       >
         <div className="flex flex-col items-center justify-center gap-8 text-center">
           <div className="flex flex-col items-center">

--- a/docs/suspensive.org/src/components/Scrollycoding.tsx
+++ b/docs/suspensive.org/src/components/Scrollycoding.tsx
@@ -122,7 +122,7 @@ export function Scrollycoding(props: unknown) {
             </Selectable>
           ))}
         </div>
-        <div className="-mr-6 rounded-xl" style={{ flex: 2 }}>
+        <div className="rounded-xl md:-mr-6" style={{ flex: 2 }}>
           <div className="scrollbar-none sticky top-28 overflow-auto">
             <Selection
               from={steps.map((step) => (


### PR DESCRIPTION
# Overview

Resolves #1543

On screen sizes below `md`, there was an issue where horizontal scrolling occurred due to overly aggressive negative margins.

To fix this, the margin of `article > section` has been adjusted to `-mx-4` for smaller screens (previously -mx-12).

Additionally, in the `Scrollycoding` component, the `-mr-6` margin applied to the code block is now limited to `md` and larger breakpoints.

<table>
<tr>
<td>
<img width="752" alt="image" src="https://github.com/user-attachments/assets/ba07cedd-97e7-46ce-b5f5-6242370d676e" />
</td>
<td>
<img width="752" alt="image" src="https://github.com/user-attachments/assets/eed2ad18-cbad-4aa3-b12c-511ce4946f99" />
</td>
</tr>
<tr>
<td align="center">
Before
</td>
<td align="center">
After
</td>
</tr>
</table>

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
