### PR TITLE
feat(codemods): add migrate with api codemod

### DIFF
--- a/.changeset/lucky-pugs-type.md
+++ b/.changeset/lucky-pugs-type.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/codemods": patch
+---
+
+feat(codemods): add migrate with api codemod

--- a/docs/suspensive.org/src/content/en/docs/codemods/_meta.tsx
+++ b/docs/suspensive.org/src/content/en/docs/codemods/_meta.tsx
@@ -8,4 +8,8 @@ export default {
     title: 'Codemods',
   },
   tanstackQueryImport: { title: 'Migrate TanStack Query imports' },
+  migrateQueryClientConsumerProps: {
+    title: 'Migrate <QueryClientConsumer/> Props',
+  },
+  migrateWithAPI: { title: 'Migrate with API' },
 } satisfies MetaRecord

--- a/docs/suspensive.org/src/content/en/docs/codemods/migrateWithAPI.mdx
+++ b/docs/suspensive.org/src/content/en/docs/codemods/migrateWithAPI.mdx
@@ -1,0 +1,56 @@
+import { Callout } from '@/components'
+
+# Migrate `with` API
+
+<Callout type='info'>
+
+This codemod is recommended when upgrading `@suspensive/react` from v2 to v3.
+
+</Callout>
+
+In `@suspensive/react` v3, the `wrap` API has been removed and replaced with the new `with` API, which is provided on each component such as `<ErrorBoundaryGroup/>`, `<ErrorBoundary/>`, and `<Suspense/>`.
+
+For more details about this breaking change, refer to the [Migrating to v3](/docs/react/migration/migrate-to-v3).
+
+```shell
+npx @suspensive/codemods migrate-with-api .
+```
+
+This codemod automatically transforms the `wrap` builder pattern into the new `with` API on each component.
+
+For example:
+
+```tsx /wrap/
+import { wrap } from '@suspensive/react'
+
+export const Example = wrap
+  .ErrorBoundaryGroup({ blockOutside: false })
+  .ErrorBoundary({
+    fallback: ({ error }) => <>{error.message}</>,
+    onError: logger.log,
+  })
+  .Suspense({ fallback: <>loading...</>, clientOnly: true })
+  .on(() => {
+    return <>Example</>
+  })
+```
+
+Transforms into:
+
+```tsx /with/
+import { ErrorBoundaryGroup, ErrorBoundary, Suspense } from '@suspensive/react'
+import { useSuspenseQuery } from '@suspensive/react-query'
+
+export const Example = ErrorBoundaryGroup.with(
+  { blockOutside: false },
+  ErrorBoundary.with(
+    {
+      fallback: ({ error }) => <>{error.message}</>,
+      onError: logger.log,
+    },
+    Suspense.with({ fallback: <>loading...</>, clientOnly: true }, () => {
+      return <>Example</>
+    })
+  )
+)
+```

--- a/docs/suspensive.org/src/content/ko/docs/codemods/_meta.tsx
+++ b/docs/suspensive.org/src/content/ko/docs/codemods/_meta.tsx
@@ -8,4 +8,8 @@ export default {
     title: 'Codemods',
   },
   tanstackQueryImport: { title: 'TanStack Query로 import 경로 변경' },
+  migrateQueryClientConsumerProps: {
+    title: '<QueryClientConsumer/> Props 변환',
+  },
+  migrateWithAPI: { title: 'with API로 변환' },
 } satisfies MetaRecord

--- a/docs/suspensive.org/src/content/ko/docs/codemods/migrateWithAPI.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/codemods/migrateWithAPI.mdx
@@ -1,0 +1,56 @@
+import { Callout } from '@/components'
+
+# `with` API로 변환
+
+<Callout type='info'>
+
+해당 codemod는 `@suspensive/react` v2 환경에서 `@suspensive/react` v3로 업데이트하는 경우 추천합니다.
+
+</Callout>
+
+`@suspensive/react` v3에서는 `wrap` API를 제거하고, `wrap`을 대체할 수 있는 `with` API를 제공합니다. 이는 각 컴포넌트 `<ErrorBoundaryGroup/>`, `<ErrorBoundary/>`, `<Suspense/>`에 추가되었습니다.
+
+브레이킹 체인지에 대해 자세한 내용은 [v3로 마이그레이션하기](/docs/react/migration/migrate-to-v3)에서 확인할 수 있습니다.
+
+```shell
+npx @suspensive/codemods migrate-with-api .
+```
+
+이 codemod를 통해 `wrap` builder 패턴을 각 컴포넌트의 `with` API로 변환할 수 있습니다.
+
+예:
+
+```tsx /wrap/
+import { wrap } from '@suspensive/react'
+
+export const Example = wrap
+  .ErrorBoundaryGroup({ blockOutside: false })
+  .ErrorBoundary({
+    fallback: ({ error }) => <>{error.message}</>,
+    onError: logger.log,
+  })
+  .Suspense({ fallback: <>loading...</>, clientOnly: true })
+  .on(() => {
+    return <>Example</>
+  })
+```
+
+변환 후:
+
+```tsx /with/
+import { ErrorBoundaryGroup, ErrorBoundary, Suspense } from '@suspensive/react'
+import { useSuspenseQuery } from '@suspensive/react-query'
+
+export const Example = ErrorBoundaryGroup.with(
+  { blockOutside: false },
+  ErrorBoundary.with(
+    {
+      fallback: ({ error }) => <>{error.message}</>,
+      onError: logger.log,
+    },
+    Suspense.with({ fallback: <>loading...</>, clientOnly: true }, () => {
+      return <>Example</>
+    })
+  )
+)
+```

--- a/examples/react-native-playground/package.json
+++ b/examples/react-native-playground/package.json
@@ -26,6 +26,7 @@
     "react-native-web": "catalog:react19"
   },
   "devDependencies": {
+    "@suspensive/eslint-config": "workspace:*",
     "@babel/core": "^7.27.1",
     "@types/jest": "^29.5.14",
     "@types/react": "catalog:react19",

--- a/packages/codemods/src/bin/transformRunner.ts
+++ b/packages/codemods/src/bin/transformRunner.ts
@@ -5,7 +5,15 @@ import prompts from 'prompts'
 const TRANSFORMER_INQUIRER_CHOICES = [
   {
     title: 'tanstack-query-import',
-    description: 'Migrate imports to @tanstack/react-query in @suspensive/react-query (using @tanstack/react-query@5)',
+    description: 'Migrate imports to @tanstack/react-query in @suspensive/react-query',
+  },
+  {
+    title: 'migrate-query-client-consumer-props',
+    description: 'Migrate QueryClientConsumer context prop to queryClient',
+  },
+  {
+    title: 'migrate-with-api',
+    description: 'Migrate wrap API to with API for Suspensive v3',
   },
 ]
 

--- a/packages/codemods/src/transforms/migrate-with-api.ts
+++ b/packages/codemods/src/transforms/migrate-with-api.ts
@@ -5,83 +5,84 @@ export default function transformer(file: FileInfo) {
   const j = createParserFromPath(file.path)
   const root = j(file.source)
 
-  const wrapNames = root
-    .find(j.ImportDeclaration, { source: { value: '@suspensive/react' } })
+  const usedSuspensiveAPIs = new Set<string>()
+  const wrapImportNodes = root.find(j.ImportDeclaration, { source: { value: '@suspensive/react' } })
+  const wrapImportNames = wrapImportNodes
     .find(j.ImportSpecifier, { imported: { name: 'wrap' } })
     .nodes()
     .map((spec) => spec.local?.name ?? 'wrap')
-
-  root.find(j.ImportDeclaration, { source: { value: '@suspensive/react' } }).forEach((path) => {
-    path.node.specifiers = path.node.specifiers?.filter(
+  for (const path of wrapImportNodes.nodes()) {
+    path.specifiers = path.specifiers?.filter(
       (spec) => !(spec.type === 'ImportSpecifier' && spec.imported.name === 'wrap')
     )
-  })
+  }
 
-  const usedAPIs = new Set<string>()
-
-  root
+  const callPaths = root
     .find(j.CallExpression, {
       callee: {
         type: 'MemberExpression',
         property: { type: 'Identifier', name: 'on' },
       },
     })
-    .forEach((path) => {
-      let current: CallExpression | CallExpression['callee'] = path.node
-      const stages: Array<{ name: string; args: CallExpression['arguments'] }> = []
+    .paths()
+  for (const path of callPaths) {
+    let current: CallExpression | CallExpression['callee'] = path.node
+    const stages: Array<{ name: string; args: CallExpression['arguments'] }> = []
 
-      while (current.type === 'CallExpression' && current.callee.type === 'MemberExpression') {
-        const prop = current.callee.property
-        if (prop.type === 'Identifier') {
-          stages.unshift({ name: prop.name, args: current.arguments })
-        }
-        current = current.callee.object
+    while (current.type === 'CallExpression' && current.callee.type === 'MemberExpression') {
+      const prop = current.callee.property
+      if (prop.type === 'Identifier') {
+        stages.unshift({ name: prop.name, args: current.arguments })
       }
+      current = current.callee.object
+    }
 
-      const isWrapRoot =
-        (current.type === 'Identifier' && wrapNames.includes(current.name)) ||
-        (current.type === 'MemberExpression' &&
-          current.object.type === 'Identifier' &&
-          wrapNames.includes(current.object.name))
-      if (!isWrapRoot) return
+    const isWrapRoot =
+      (current.type === 'Identifier' && wrapImportNames.includes(current.name)) ||
+      (current.type === 'MemberExpression' &&
+        current.object.type === 'Identifier' &&
+        wrapImportNames.includes(current.object.name))
+    if (!isWrapRoot) continue // not a wrap root
 
-      const onStage = stages.find((s) => s.name === 'on')
-      if (!onStage) return
-      const optionStages = stages.filter((s) => s.name !== 'on')
-      optionStages.forEach((stage) => usedAPIs.add(stage.name))
+    const onStage = stages.find((s) => s.name === 'on')
+    if (!onStage) continue // not exist on
+    const wrapComponentStages = stages.filter((s) => s.name !== 'on')
+    for (const stage of wrapComponentStages) {
+      usedSuspensiveAPIs.add(stage.name)
+    }
 
-      let expr = onStage.args[0]
-      for (let i = optionStages.length - 1; i >= 0; i--) {
-        const { name, args } = optionStages[i]
-        const options = args[0] ?? j.objectExpression([])
-        expr = j.callExpression(j.memberExpression(j.identifier(name), j.identifier('with')), [options, expr])
-      }
+    let withNode = onStage.args[0]
+    for (let i = wrapComponentStages.length - 1; i >= 0; i--) {
+      const { name, args } = wrapComponentStages[i]
+      const options = args[0] ?? j.objectExpression([])
+      withNode = j.callExpression(j.memberExpression(j.identifier(name), j.identifier('with')), [options, withNode])
+    }
 
-      j(path).replaceWith(expr)
-    })
+    j(path).replaceWith(withNode)
+  }
 
-  if (usedAPIs.size > 0) {
-    const reactImport = root.find(j.ImportDeclaration, { source: { value: '@suspensive/react' } })
-    if (reactImport.size() > 0) {
-      reactImport.forEach((path) => {
-        const existing = path.node.specifiers?.map((spec) =>
+  if (usedSuspensiveAPIs.size > 0) {
+    const suspensiveReactImport = root.find(j.ImportDeclaration, { source: { value: '@suspensive/react' } })
+    if (suspensiveReactImport.size() > 0) {
+      for (const path of suspensiveReactImport.nodes()) {
+        const existing = path.specifiers?.map((spec) =>
           spec.type === 'ImportSpecifier' ? spec.imported.name : spec.local?.name
         )
-        usedAPIs.forEach((name) => {
+        for (const name of Array.from(usedSuspensiveAPIs)) {
           if (!existing?.includes(name)) {
-            path.node.specifiers?.push(j.importSpecifier(j.identifier(name)))
+            path.specifiers?.push(j.importSpecifier(j.identifier(name)))
           }
-        })
-      })
+        }
+      }
     } else {
-      root.find(j.Program).forEach((path) => {
-        path.node.body.unshift(
+      for (const path of root.find(j.Program).nodes()) {
+        path.body.unshift(
           j.importDeclaration(
-            Array.from(usedAPIs).map((name) => j.importSpecifier(j.identifier(name))),
+            Array.from(usedSuspensiveAPIs).map((name) => j.importSpecifier(j.identifier(name))),
             j.literal('@suspensive/react')
           )
         )
-      })
+      }
     }
 
     return root.toSource()

--- a/packages/codemods/src/transforms/migrate-with-api.ts
+++ b/packages/codemods/src/transforms/migrate-with-api.ts
@@ -1,0 +1,89 @@
+import type { CallExpression, FileInfo } from 'jscodeshift'
+import { createParserFromPath } from './utils/createParserFromPath'
+
+export default function transformer(file: FileInfo) {
+  const j = createParserFromPath(file.path)
+  const root = j(file.source)
+
+  const wrapNames = root
+    .find(j.ImportDeclaration, { source: { value: '@suspensive/react' } })
+    .find(j.ImportSpecifier, { imported: { name: 'wrap' } })
+    .nodes()
+    .map((spec) => spec.local?.name ?? 'wrap')
+
+  root.find(j.ImportDeclaration, { source: { value: '@suspensive/react' } }).forEach((path) => {
+    path.node.specifiers = path.node.specifiers?.filter(
+      (spec) => !(spec.type === 'ImportSpecifier' && spec.imported.name === 'wrap')
+    )
+  })
+
+  const usedAPIs = new Set<string>()
+
+  root
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        property: { type: 'Identifier', name: 'on' },
+      },
+    })
+    .forEach((path) => {
+      let current: CallExpression | CallExpression['callee'] = path.node
+      const stages: Array<{ name: string; args: CallExpression['arguments'] }> = []
+
+      while (current.type === 'CallExpression' && current.callee.type === 'MemberExpression') {
+        const prop = current.callee.property
+        if (prop.type === 'Identifier') {
+          stages.unshift({ name: prop.name, args: current.arguments })
+        }
+        current = current.callee.object
+      }
+
+      const isWrapRoot =
+        (current.type === 'Identifier' && wrapNames.includes(current.name)) ||
+        (current.type === 'MemberExpression' &&
+          current.object.type === 'Identifier' &&
+          wrapNames.includes(current.object.name))
+      if (!isWrapRoot) return
+
+      const onStage = stages.find((s) => s.name === 'on')
+      if (!onStage) return
+      const optionStages = stages.filter((s) => s.name !== 'on')
+      optionStages.forEach((stage) => usedAPIs.add(stage.name))
+
+      let expr = onStage.args[0]
+      for (let i = optionStages.length - 1; i >= 0; i--) {
+        const { name, args } = optionStages[i]
+        const options = args[0] ?? j.objectExpression([])
+        expr = j.callExpression(j.memberExpression(j.identifier(name), j.identifier('with')), [options, expr])
+      }
+
+      j(path).replaceWith(expr)
+    })
+
+  if (usedAPIs.size > 0) {
+    const reactImport = root.find(j.ImportDeclaration, { source: { value: '@suspensive/react' } })
+    if (reactImport.size() > 0) {
+      reactImport.forEach((path) => {
+        const existing = path.node.specifiers?.map((spec) =>
+          spec.type === 'ImportSpecifier' ? spec.imported.name : spec.local?.name
+        )
+        usedAPIs.forEach((name) => {
+          if (!existing?.includes(name)) {
+            path.node.specifiers?.push(j.importSpecifier(j.identifier(name)))
+          }
+        })
+      })
+    } else {
+      root.find(j.Program).forEach((path) => {
+        path.node.body.unshift(
+          j.importDeclaration(
+            Array.from(usedAPIs).map((name) => j.importSpecifier(j.identifier(name))),
+            j.literal('@suspensive/react')
+          )
+        )
+      })
+    }
+
+    return root.toSource()
+  }
+}

--- a/packages/codemods/src/transforms/testfixtures/migrate-with-api/migrate-with-api.input.jsx
+++ b/packages/codemods/src/transforms/testfixtures/migrate-with-api/migrate-with-api.input.jsx
@@ -1,0 +1,42 @@
+
+import { wrap } from '@suspensive/react'
+import { useSuspenseQuery } from '@suspensive/react-query'
+
+export const Case1 = wrap
+  .ErrorBoundaryGroup({ blockOutside: false })
+  .ErrorBoundary({
+    fallback: ({ error }) => <>{error.message}</>,
+    onError: logger.log,
+  })
+  .Suspense({ fallback: <>loading...</>, clientOnly: true })
+  .on(() => {
+    const query = useSuspenseQuery({
+      queryKey: ['key'],
+      queryFn: () => api.text(),
+    })
+    return <>{query.data.text}</>
+  })
+
+export const Case2 = wrap
+  .ErrorBoundary({
+    fallback: ({ error }) => <>{error.message}</>,
+    onError: logger.log,
+  })
+  .Suspense()
+  .on((_props) => {
+    const query = useSuspenseQuery({
+      queryKey: ['key'],
+      queryFn: () => api.text(),
+    })
+    return <>{query.data.text}</>
+  })
+
+export const Case3 = wrap
+  .Suspense()
+  .on((_props) => {
+    const query = useSuspenseQuery({
+      queryKey: ['key'],
+      queryFn: () => api.text(),
+    })
+    return <>{query.data.text}</>
+  })

--- a/packages/codemods/src/transforms/testfixtures/migrate-with-api/migrate-with-api.input.jsx
+++ b/packages/codemods/src/transforms/testfixtures/migrate-with-api/migrate-with-api.input.jsx
@@ -1,4 +1,3 @@
-
 import { wrap } from '@suspensive/react'
 import { useSuspenseQuery } from '@suspensive/react-query'
 

--- a/packages/codemods/src/transforms/testfixtures/migrate-with-api/migrate-with-api.output.jsx
+++ b/packages/codemods/src/transforms/testfixtures/migrate-with-api/migrate-with-api.output.jsx
@@ -1,0 +1,32 @@
+import { ErrorBoundaryGroup, ErrorBoundary, Suspense } from '@suspensive/react';
+import { useSuspenseQuery } from '@suspensive/react-query'
+
+export const Case1 = ErrorBoundaryGroup.with({ blockOutside: false }, ErrorBoundary.with({
+    fallback: ({ error }) => <>{error.message}</>,
+    onError: logger.log,
+  }, Suspense.with({ fallback: <>loading...</>, clientOnly: true }, () => {
+    const query = useSuspenseQuery({
+      queryKey: ['key'],
+      queryFn: () => api.text(),
+    })
+    return <>{query.data.text}</>
+  })))
+
+export const Case2 = ErrorBoundary.with({
+    fallback: ({ error }) => <>{error.message}</>,
+    onError: logger.log,
+  }, Suspense.with({}, (_props) => {
+    const query = useSuspenseQuery({
+      queryKey: ['key'],
+      queryFn: () => api.text(),
+    })
+    return <>{query.data.text}</>
+  }))
+
+export const Case3 = Suspense.with({}, (_props) => {
+    const query = useSuspenseQuery({
+      queryKey: ['key'],
+      queryFn: () => api.text(),
+    })
+    return <>{query.data.text}</>
+  })

--- a/packages/codemods/src/transforms/tests/migrate-with-api.test.ts
+++ b/packages/codemods/src/transforms/tests/migrate-with-api.test.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error - type definitions not available
+import { defineInlineTest } from 'jscodeshift/dist/testUtils'
+import transform from '../migrate-with-api'
+import { getTestfixtures } from '../utils/getTestfixtures'
+
+const { input, expectedOutput, testName } = getTestfixtures('migrate-with-api', 'jsx')
+
+defineInlineTest(transform, null, input, expectedOutput, testName)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,9 @@ importers:
       '@babel/core':
         specifier: ^7.27.1
         version: 7.27.1
+      '@suspensive/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -2480,85 +2483,72 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.1':
     resolution: {integrity: sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.1':
     resolution: {integrity: sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.1':
     resolution: {integrity: sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.1':
     resolution: {integrity: sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.1':
     resolution: {integrity: sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.1':
     resolution: {integrity: sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.1':
     resolution: {integrity: sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==}
@@ -2789,42 +2779,36 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/simple-git-linux-arm64-musl@0.1.19':
     resolution: {integrity: sha512-OwTRF+H4IZYxmDFRi1IrLMfqbdIpvHeYbJl2X94NVsLVOY+3NUHvEzL3fYaVx5urBaMnIK0DD3wZLbcueWvxbA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/simple-git-linux-powerpc64le-gnu@0.1.19':
     resolution: {integrity: sha512-p7zuNNVyzpRvkCt2RIGv9FX/WPcPbZ6/FRUgUTZkA2WU33mrbvNqSi4AOqCCl6mBvEd+EOw5NU4lS9ORRJvAEg==}
     engines: {node: '>= 10'}
     cpu: [powerpc64le]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/simple-git-linux-s390x-gnu@0.1.19':
     resolution: {integrity: sha512-6N2vwJUPLiak8GLrS0a3is0gSb0UwI2CHOOqtvQxPmv+JVI8kn3vKiUscsktdDb0wGEPeZ8PvZs0y8UWix7K4g==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/simple-git-linux-x64-gnu@0.1.19':
     resolution: {integrity: sha512-61YfeO1J13WK7MalLgP3QlV6of2rWnVw1aqxWkAgy/lGxoOFSJ4Wid6ANVCEZk4tJpPX/XNeneqkUz5xpeb2Cw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/simple-git-linux-x64-musl@0.1.19':
     resolution: {integrity: sha512-cCTWNpMJnN3PrUBItWcs3dQKCydsIasbrS3laMzq8k7OzF93Zrp2LWDTPlLCO9brbBVpBzy2Qk5Xg9uAfe/Ukw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/simple-git-win32-arm64-msvc@0.1.19':
     resolution: {integrity: sha512-sWavb1BjeLKKBA+PbTsRSSzVNfb7V/dOpaJvkgR5d2kWFn/AHmCZHSSj/3nyZdYf0BdDC+DIvqk3daAEZ6QMVw==}
@@ -2865,28 +2849,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.3.1':
     resolution: {integrity: sha512-IIxXEXRti/AulO9lWRHiCpUUR8AR/ZYLPALgiIg/9ENzMzLn3l0NSxVdva7R/VDcuSEBo0eGVCe3evSIHNz0Hg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.3.1':
     resolution: {integrity: sha512-bfI4AMhySJbyXQIKH5rmLJ5/BP7bPwuxauTvVEiJ/ADoddaA9fgyNNCcsbu9SlqfHDoZmfI6g2EjzLwbsVTr5A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.3.1':
     resolution: {integrity: sha512-FeAbR7FYMWR+Z+M5iSGytVryKHiAsc0x3Nc3J+FD5NVbD5Mqz7fTSy8CYliXinn7T26nDMbpExRUI/4ekTvoiA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.3.1':
     resolution: {integrity: sha512-yP7FueWjphQEPpJQ2oKmshk/ppOt+0/bB8JC8svPUZNy0Pi3KbPx2Llkzv1p8CoQa+D2wknINlJpHf3vtChVBw==}
@@ -3279,61 +3259,51 @@ packages:
     resolution: {integrity: sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.9':
     resolution: {integrity: sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.34.9':
     resolution: {integrity: sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.34.9':
     resolution: {integrity: sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.9':
     resolution: {integrity: sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.9':
     resolution: {integrity: sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.9':
     resolution: {integrity: sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.34.9':
     resolution: {integrity: sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.34.9':
     resolution: {integrity: sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.34.9':
     resolution: {integrity: sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.34.9':
     resolution: {integrity: sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==}
@@ -3440,28 +3410,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.3':
     resolution: {integrity: sha512-dm18aQiML5QCj9DQo7wMbt1Z2tl3Giht54uVR87a84X8qRtuXxUqnKQkRDK5B4bCOmcZ580lF9YcoMkbDYTXHQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.3':
     resolution: {integrity: sha512-LMdTmGe/NPtGOaOfV2HuO7w07jI3cflPrVq5CXl+2O93DCewADK0uW1ORNAcfu2YxDUS035eY2W38TxrsqngxA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.3':
     resolution: {integrity: sha512-aalNWwIi54bbFEizwl1/XpmdDrOaCjRFQRgtbv9slWjmNPuJJTIKPHf5/XXDARc9CneW9FkSTqTbyvNecYAEGw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.1.3':
     resolution: {integrity: sha512-PEj7XR4OGTGoboTIAdXicKuWl4EQIjKHKuR+bFy9oYN7CFZo0eu74+70O4XuERX4yjqVZGAkCdglBODlgqcCXg==}
@@ -7419,56 +7385,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.29.2:
     resolution: {integrity: sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.27.0:
     resolution: {integrity: sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.29.2:
     resolution: {integrity: sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.27.0:
     resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.29.2:
     resolution: {integrity: sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.27.0:
     resolution: {integrity: sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.29.2:
     resolution: {integrity: sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.27.0:
     resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}


### PR DESCRIPTION
# Overview

related: #1539 

Add a codemod that converts the `wrap` API to `with`(`ErrorBoundaryGroup`, `ErrorBoundary`, `Suspense`) for the breaking change in `@suspensive/react v3`

- Remove `wrap` from the import declaration and declare only the APIs being used.
- Convert the HoC components used in `wrap` to the `with` interface.

## PoC

![image](https://github.com/user-attachments/assets/ab09066c-1d6f-4949-9ae4-efca9db10a07)

- This codemod has been applied and confirmed to work properly by the enterprise team I belong to.
- Out of a total of 551 components, 60 components using `wrap` were reliably converted in a 28-second operation.

## AS-IS
import { wrap } from '@suspensive/react'
import { useSuspenseQuery } from '@suspensive/react-query'

```jsx
export const Case1 = wrap
  .ErrorBoundaryGroup({ blockOutside: false })
  .ErrorBoundary({
    fallback: ({ error }) => <>{error.message}</>,
    onError: logger.log,
  })
  .Suspense({ fallback: <>loading...</>, clientOnly: true })
  .on(() => {
    const query = useSuspenseQuery({
      queryKey: ['key'],
      queryFn: () => api.text(),
    })
    return <>{query.data.text}</>
  })
```

## TO-BE
import { ErrorBoundaryGroup, ErrorBoundary, Suspense } from '@suspensive/react';
import { useSuspenseQuery } from '@suspensive/react-query'

```jsx
export const Case1 = ErrorBoundaryGroup.with({ blockOutside: false }, ErrorBoundary.with({
    fallback: ({ error }) => <>{error.message}</>,
    onError: logger.log,
  }, Suspense.with({ fallback: <>loading...</>, clientOnly: true }, () => {
    const query = useSuspenseQuery({
      queryKey: ['key'],
      queryFn: () => api.text(),
    })
    return <>{query.data.text}</>
  })))
```

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
3. I added documents and tests.
