### PR TITLE
refactor(react): update ErrorBoundary reset type to arrow function to fix unbound-method lint error

### DIFF
--- a/.changeset/new-drinks-sit.md
+++ b/.changeset/new-drinks-sit.md
@@ -1,0 +1,5 @@
+---
+'@suspensive/react': patch
+---
+
+refactor(react): change ErrorBoundary prop types to arrow functions and remove eslint-disable

--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -54,11 +54,11 @@ export type ErrorBoundaryProps = PropsWithChildren<{
   /**
    * when ErrorBoundary is reset by resetKeys or fallback's props.reset, onReset will be triggered
    */
-  onReset?(): void
+  onReset?: () => void
   /**
    * when ErrorBoundary catch error, onError will be triggered
    */
-  onError?(error: Error, info: ErrorInfo): void
+  onError?: (error: Error, info: ErrorInfo) => void
   /**
    * when ErrorBoundary catch error, fallback will be render instead of children
    */
@@ -167,8 +167,6 @@ class FallbackBoundary extends Component<{ children: ReactNode }> {
  */
 export const ErrorBoundary = Object.assign(
   forwardRef<{ reset(): void }, ErrorBoundaryProps>(
-    // TODO: remove this line
-    // eslint-disable-next-line @typescript-eslint/unbound-method
     ({ fallback, children, onError, onReset, resetKeys, shouldCatch }, ref) => {
       const group = useContext(ErrorBoundaryGroupContext) ?? { resetKey: 0 }
       const baseErrorBoundaryRef = useRef<BaseErrorBoundary>(null)

--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -166,7 +166,7 @@ class FallbackBoundary extends Component<{ children: ReactNode }> {
  * @see {@link https://suspensive.org/docs/react/ErrorBoundary Suspensive Docs}
  */
 export const ErrorBoundary = Object.assign(
-  forwardRef<{ reset(): void }, ErrorBoundaryProps>(
+  forwardRef<{ reset: () => void }, ErrorBoundaryProps>(
     ({ fallback, children, onError, onReset, resetKeys, shouldCatch }, ref) => {
       const group = useContext(ErrorBoundaryGroupContext) ?? { resetKey: 0 }
       const baseErrorBoundaryRef = useRef<BaseErrorBoundary>(null)


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

- Updated `onReset`, `onError`, and `reset` type annotations to use arrow function types for consistency
- This change resolves the `@typescript-eslint/unbound-method` lint warning, which can occur when method signatures are passed without binding

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
