### PR TITLE
docs: fix language inconsistency in Delay.with section

### DIFF
--- a/docs/suspensive.org/src/content/en/docs/react/Delay.mdx
+++ b/docs/suspensive.org/src/content/en/docs/react/Delay.mdx
@@ -151,8 +151,8 @@ export const Example = () => {
 
 ## Delay.with
 
-`Delay.with`는 `Delay`를 사용하여 컴포넌트를 래핑하는 HOC입니다.
-`Delay.with`를 사용하면 컴포넌트를 쉽게 래핑할 수 있습니다.
+`Delay.with` is a higher-order component (HOC) that wraps a component using `Delay`.
+`Delay.with` makes it easy to wrap a component.
 
 ```tsx /Delay.with/
 import { Delay } from '@suspensive/react'


### PR DESCRIPTION
# Overview

This PR fixes a language inconsistency in the English documentation where the "Delay.with" section in `docs/suspensive.org/src/content/en/docs/react/Delay.mdx` was written in Korean while the rest of the document is in English.

## Changes

- Translated the "Delay.with" section from Korean to English
- Maintained the same structure and content, just in the appropriate language
- Preserved the code example which remains the same

## Rationale

This change ensures language consistency across all English documentation. Since this file is in the `/en/docs/` path, all content should be in English to maintain proper documentation standards and improve user experience.

No changes were made to the functionality or technical content - this is purely a documentation language fix.

## PR Checklist

- [x] I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
- [x] I added documents and tests.