### PR TITLE
feat(codemods, suspensive.org): add remove networkmode codemod for v3 migration

### DIFF
--- a/.changeset/tidy-cherries-judge.md
+++ b/.changeset/tidy-cherries-judge.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/codemods": minor
+---
+
+feat(codemods, suspensive.org): add remove networkmode codemod for v3 migration

--- a/.changeset/tidy-cherries-judge.md
+++ b/.changeset/tidy-cherries-judge.md
@@ -2,4 +2,4 @@
 "@suspensive/codemods": minor
 ---
 
-feat(codemods, suspensive.org): add remove networkmode codemod for v3 migration
+feat(codemods): add remove-networkmode codemod for v3 migration

--- a/docs/suspensive.org/src/content/en/docs/codemods/_meta.tsx
+++ b/docs/suspensive.org/src/content/en/docs/codemods/_meta.tsx
@@ -12,4 +12,5 @@ export default {
     title: 'Migrate <QueryClientConsumer/> Props',
   },
   migrateWithAPI: { title: 'Migrate with API' },
+  removeNetworkmode: { title: 'Remove NetworkMode' },
 } satisfies MetaRecord

--- a/docs/suspensive.org/src/content/en/docs/codemods/removeNetworkmode.mdx
+++ b/docs/suspensive.org/src/content/en/docs/codemods/removeNetworkmode.mdx
@@ -1,0 +1,42 @@
+import { Callout } from '@/components'
+
+# Remove `networkMode`
+
+<Callout type='info'>
+
+We recommend running this when upgrading from `@suspensive/react-query` v2 & `@tanstack/react-query@4` to `@suspensive/react-query` v3.
+
+</Callout>
+
+In `@suspensive/react-query` v3, the Suspense API has `networkMode` hardcoded as `'always'` and it can no longer be modified.
+
+For full details on the breaking changes that this codemod helps with, refer to [Migrating to v3](/docs/react-query/migration/migrate-to-v3).
+
+```bash filename="Terminal"
+npx @suspensive/codemods remove-networkmode .
+```
+
+This codemod safely and easily removes unnecessary `networkMode` properties from Suspense API usage.
+
+For example:
+
+```tsx /networkMode/
+import { queryOptions } from '@tanstack/react-query'
+
+const options = queryOptions({
+  queryKey: ['key'],
+  queryFn: () => Promise.resolve('data'),
+  networkMode: 'always',
+})
+```
+
+Transforms into:
+
+```tsx /networkMode/
+import { queryOptions } from '@tanstack/react-query'
+
+const options = queryOptions({
+  queryKey: ['key'],
+  queryFn: () => Promise.resolve('data'),
+})
+```

--- a/docs/suspensive.org/src/content/ko/docs/codemods/_meta.tsx
+++ b/docs/suspensive.org/src/content/ko/docs/codemods/_meta.tsx
@@ -12,4 +12,5 @@ export default {
     title: '<QueryClientConsumer/> Props 변환',
   },
   migrateWithAPI: { title: 'with API로 변환' },
+  removeNetworkmode: { title: 'networkMode 제거' },
 } satisfies MetaRecord

--- a/docs/suspensive.org/src/content/ko/docs/codemods/removeNetworkmode.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/codemods/removeNetworkmode.mdx
@@ -1,0 +1,42 @@
+import { Callout } from '@/components'
+
+# `networkMode` 제거
+
+<Callout type='info'>
+
+`@suspensive/react-query` v2 & `@tanstack/react-query@4`에서 `@suspensive/react-query` v3로 업데이트하는 경우 추천합니다.
+
+</Callout>
+
+`@suspensive/react-query` v3에서는 Suspense API에서 `networkMode`를 'always'로 고정하고 수정할 수 없습니다.
+
+해당 코드모드가 도움이 될 수 있는 v3 브레이킹 체인지에 대해 자세한 내용은 [v3로 마이그레이션하기](/docs/react-query/migration/migrate-to-v3)에서 확인할 수 있습니다.
+
+```bash filename="Terminal"
+npx @suspensive/codemods remove-networkmode .
+```
+
+이 codemod를 통해 Suspense API에서 제거가 필요한 `networkMode`를 쉽고 안전하게 제거할 수 있습니다.
+
+예:
+
+```tsx /networkMode/
+import { queryOptions } from '@tanstack/react-query'
+
+const options = queryOptions({
+  queryKey: ['key'],
+  queryFn: () => Promise.resolve('data'),
+  networkMode: 'always',
+})
+```
+
+변환 후:
+
+```tsx /networkMode/
+import { queryOptions } from '@tanstack/react-query'
+
+const options = queryOptions({
+  queryKey: ['key'],
+  queryFn: () => Promise.resolve('data'),
+})
+```

--- a/docs/suspensive.org/src/content/ko/docs/codemods/removeNetworkmode.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/codemods/removeNetworkmode.mdx
@@ -10,13 +10,13 @@ import { Callout } from '@/components'
 
 `@suspensive/react-query` v3에서는 Suspense API에서 `networkMode`를 'always'로 고정하고 수정할 수 없습니다.
 
-해당 코드모드가 도움이 될 수 있는 v3 브레이킹 체인지에 대해 자세한 내용은 [v3로 마이그레이션하기](/docs/react-query/migration/migrate-to-v3)에서 확인할 수 있습니다.
+해당 Codemod가 도움이 될 수 있는 v3 브레이킹 체인지에 대해 자세한 내용은 [v3로 마이그레이션하기](/docs/react-query/migration/migrate-to-v3)에서 확인할 수 있습니다.
 
 ```bash filename="Terminal"
 npx @suspensive/codemods remove-networkmode .
 ```
 
-이 codemod를 통해 Suspense API에서 제거가 필요한 `networkMode`를 쉽고 안전하게 제거할 수 있습니다.
+Suspense API에서 제거가 필요한 `networkMode`를 쉽고 안전하게 제거할 수 있습니다.
 
 예:
 

--- a/packages/codemods/src/bin/transformRunner.ts
+++ b/packages/codemods/src/bin/transformRunner.ts
@@ -15,6 +15,10 @@ const TRANSFORMER_INQUIRER_CHOICES = [
     title: 'migrate-with-api',
     description: 'Migrate wrap API to with API for Suspensive v3',
   },
+  {
+    title: 'remove-networkmode',
+    description: 'Remove networkMode from Suspense API',
+  },
 ]
 
 function onCancel() {

--- a/packages/codemods/src/transforms/remove-networkmode.ts
+++ b/packages/codemods/src/transforms/remove-networkmode.ts
@@ -1,0 +1,58 @@
+import type { FileInfo } from 'jscodeshift'
+import { createParserFromPath } from './utils/createParserFromPath'
+
+const TARGET_FUNCTIONS = new Set([
+  'queryOptions',
+  'infiniteQueryOptions',
+  'useSuspenseQuery',
+  'useSuspenseInfiniteQuery',
+  'SuspenseQuery',
+  'SuspenseInfiniteQuery',
+])
+
+export default function transform(file: FileInfo) {
+  const j = createParserFromPath(file.path)
+  const root = j(file.source)
+
+  root
+    .find(j.CallExpression, {
+      callee: {
+        type: 'Identifier',
+      },
+    })
+    .forEach((path) => {
+      if (path.node.callee.type !== 'Identifier') {
+        return
+      }
+      const calleeName = path.node.callee.name
+      if (!TARGET_FUNCTIONS.has(calleeName)) {
+        return
+      }
+
+      const args = path.node.arguments
+      if (args.length === 0) {
+        return
+      }
+
+      const firstArg = args[0]
+      if (firstArg.type !== 'ObjectExpression') {
+        return
+      }
+
+      const properties = firstArg.properties
+      const networkModeIndex = properties.findIndex((prop) => {
+        if (prop.type === 'ObjectProperty' && prop.key.type === 'Identifier' && prop.key.name === 'networkMode') {
+          if (prop.value.type === 'StringLiteral' && prop.value.value === 'always') {
+            return true
+          }
+        }
+        return false
+      })
+
+      if (networkModeIndex !== -1) {
+        properties.splice(networkModeIndex, 1)
+      }
+    })
+
+  return root.toSource()
+}

--- a/packages/codemods/src/transforms/testfixtures/remove-networkmode/remove-networkmode.input.jsx
+++ b/packages/codemods/src/transforms/testfixtures/remove-networkmode/remove-networkmode.input.jsx
@@ -1,0 +1,51 @@
+const options = queryOptions({
+  queryKey: ['key'],
+  networkMode: 'always',
+  queryFn: () => Promise.resolve('data'),
+});
+
+const options2 = notQueryOptions({
+  queryKey: ['key'],
+  networkMode: 'always',
+  queryFn: () => Promise.resolve('data'),
+});
+
+const result = useSuspenseQuery({
+  queryKey: ['key'],
+  networkMode: 'always',
+  queryFn: () => Promise.resolve('data'),
+});
+
+const options3 = queryOptions({
+  networkMode: 'always',
+  queryKey: ['key'],
+  queryFn: () => Promise.resolve('data'),
+});
+
+const options4 = queryOptions({
+  queryKey: ['key'],
+  staleTime: 5000,
+  networkMode: 'always',
+  retry: 2,
+  queryFn: () => Promise.resolve('data'),
+});
+
+const options5 = queryOptions({
+  queryKey: ['key'],
+  networkMode: 'offlineFirst',
+  queryFn: () => Promise.resolve('data'),
+});
+
+const options6 = api.useSuspenseQuery({
+  queryKey: ['key'],
+  networkMode: 'always',
+  queryFn: () => Promise.resolve('data'),
+});
+
+const options7 = queryOptions('invalid');
+
+const params = {
+  queryKey: ['key'],
+  networkMode: 'always',
+};
+const options8 = queryOptions(params);

--- a/packages/codemods/src/transforms/testfixtures/remove-networkmode/remove-networkmode.output.jsx
+++ b/packages/codemods/src/transforms/testfixtures/remove-networkmode/remove-networkmode.output.jsx
@@ -1,0 +1,47 @@
+const options = queryOptions({
+  queryKey: ['key'],
+  queryFn: () => Promise.resolve('data')
+});
+
+const options2 = notQueryOptions({
+  queryKey: ['key'],
+  networkMode: 'always',
+  queryFn: () => Promise.resolve('data'),
+});
+
+const result = useSuspenseQuery({
+  queryKey: ['key'],
+  queryFn: () => Promise.resolve('data')
+});
+
+const options3 = queryOptions({
+  queryKey: ['key'],
+  queryFn: () => Promise.resolve('data')
+});
+
+const options4 = queryOptions({
+  queryKey: ['key'],
+  staleTime: 5000,
+  retry: 2,
+  queryFn: () => Promise.resolve('data')
+});
+
+const options5 = queryOptions({
+  queryKey: ['key'],
+  networkMode: 'offlineFirst',
+  queryFn: () => Promise.resolve('data'),
+});
+
+const options6 = api.useSuspenseQuery({
+  queryKey: ['key'],
+  networkMode: 'always',
+  queryFn: () => Promise.resolve('data'),
+});
+
+const options7 = queryOptions('invalid');
+
+const params = {
+  queryKey: ['key'],
+  networkMode: 'always',
+};
+const options8 = queryOptions(params);

--- a/packages/codemods/src/transforms/tests/remove-networkmode.test.ts
+++ b/packages/codemods/src/transforms/tests/remove-networkmode.test.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error - type definitions not available
+import { defineInlineTest } from 'jscodeshift/dist/testUtils'
+import transform from '../remove-networkmode'
+import { getTestfixtures } from '../utils/getTestfixtures'
+
+const { input, expectedOutput, testName } = getTestfixtures('remove-networkmode', 'jsx')
+
+defineInlineTest(transform, null, input, expectedOutput, testName)


### PR DESCRIPTION
# Overview

closed: #1539 

I have created all the necessary codemod tools for the suspensive v3 migration! Users can now safely and quickly resolve the breaking changes of v3.

## PoC

- [AST Explorer](https://astexplorer.net/#/gist/e73a8fc864d3bacf96540bf601dece8a/latest)

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
