### PR TITLE
test(react/ErrorBoundary): use default props in 'ErrorBoundary.with' when passed 'undefined'

### DIFF
--- a/packages/react/src/ErrorBoundary.spec.tsx
+++ b/packages/react/src/ErrorBoundary.spec.tsx
@@ -336,6 +336,7 @@ describe('<ErrorBoundary/>', () => {
     await waitFor(() => expect(screen.queryByText("ErrorBoundary's fallback before error")).toBeInTheDocument())
     await waitFor(() => expect(screen.queryByText('This is expected')).toBeInTheDocument())
   })
+
   it('should not re-throw error in fallback (react-error-boundary)', async () => {
     render(
       <ReactErrorBoundary fallbackRender={() => <>This is expected</>}>
@@ -498,6 +499,7 @@ describe('useErrorBoundaryFallbackProps', () => {
     ).toThrow(SuspensiveError)
     expect(inFallback).toHaveBeenCalledTimes(0)
   })
+
   it('should be prevented to be called outside fallback of ErrorBoundary', () => {
     expect(() =>
       render(
@@ -508,6 +510,7 @@ describe('useErrorBoundaryFallbackProps', () => {
       )
     ).toThrow(SuspensiveError)
   })
+
   it("should be prevented to be called in children of ErrorBoundary (ErrorBoundary shouldn't catch SuspensiveError)", () => {
     const inFallback = vi.fn()
     expect(() =>
@@ -534,6 +537,11 @@ describe('ErrorBoundary.with', () => {
 
   it("should render the wrapped component when there's no error", () => {
     render(createElement(ErrorBoundary.with({ fallback: (props) => <>{props.error.message}</> }, () => <>{TEXT}</>)))
+    expect(screen.queryByText(TEXT)).toBeInTheDocument()
+  })
+
+  it('should use default errorBoundaryProps when undefined is provided', () => {
+    render(createElement(ErrorBoundary.with(undefined, () => <>{TEXT}</>)))
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
   })
 


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

* relate #1464 

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
