### PR TITLE
test(react/ErrorBoundaryGroup): use default props in 'ErrorBoundaryGroup.with' when passed 'undefined'

### DIFF
--- a/packages/react/src/ErrorBoundaryGroup.spec.tsx
+++ b/packages/react/src/ErrorBoundaryGroup.spec.tsx
@@ -119,6 +119,18 @@ describe('ErrorBoundaryGroup.with', () => {
     expect(rendered.queryByText(TEXT)).toBeInTheDocument()
   })
 
+  it('should use default errorBoundaryGroupProps when undefined is provided', () => {
+    const rendered = render(
+      createElement(
+        ErrorBoundaryGroup.with(undefined, () => {
+          useErrorBoundaryGroup()
+          return <>{TEXT}</>
+        })
+      )
+    )
+    expect(rendered.queryByText(TEXT)).toBeInTheDocument()
+  })
+
   it('should set displayName based on Component.displayName', () => {
     const Component = () => <></>
     Component.displayName = 'Custom'


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

* relate #1464 

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
