### PR TITLE
test(codemods/getTestfixtures): add test for reading fixture files with default 'js' extension

### DIFF
--- a/packages/codemods/src/transforms/utils/getTestfixtures.spec.ts
+++ b/packages/codemods/src/transforms/utils/getTestfixtures.spec.ts
@@ -40,6 +40,24 @@ describe('getTestfixtures', () => {
     expect(mockReadFileSync).toHaveBeenCalledWith(outputPath, 'utf8')
   })
 
+  it('should correctly read input and output fixture files with default "js" extension', () => {
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath === inputPath) return mockInput
+      if (filePath === outputPath) return mockOutput
+      return ''
+    })
+
+    const result = getTestfixtures(transformName)
+
+    expect(result).toEqual({
+      input: mockInput,
+      expectedOutput: mockOutput,
+      testName: transformName,
+    })
+    expect(mockReadFileSync).toHaveBeenCalledWith(inputPath, 'utf8')
+    expect(mockReadFileSync).toHaveBeenCalledWith(outputPath, 'utf8')
+  })
+
   it('should throw an error if input file is missing', () => {
     mockReadFileSync.mockImplementation((filePath: string) => {
       if (filePath === outputPath) return mockOutput


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

* relate #1464 

## before

<img width="856" alt="image" src="https://github.com/user-attachments/assets/54c9f2ac-9e7f-4b78-a882-038a40d99bc0" />

## after

<img width="841" alt="image" src="https://github.com/user-attachments/assets/8d2d660f-e5f7-4303-ad26-f7f23c7435af" />

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
