### PR TITLE
test(react/ErrorBoundary): reduce overall test time with 'useFakeTimers' and 'useRealTimers'

### DIFF
--- a/packages/react/src/ErrorBoundary.spec.tsx
+++ b/packages/react/src/ErrorBoundary.spec.tsx
@@ -13,12 +13,12 @@ import { SuspensiveError } from './models/SuspensiveError'
 import { CustomError, ERROR_MESSAGE, FALLBACK, TEXT, Throw } from './test-utils'
 
 describe('<ErrorBoundary/>', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
+  beforeEach(() => vi.useFakeTimers())
+
+  afterEach(() => {
+    vi.useRealTimers()
     Throw.reset()
   })
-
-  afterEach(() => vi.useRealTimers())
 
   it('should show children if no error but if error in children, catch it and show fallback and call onError', async () => {
     const onError = vi.fn()

--- a/packages/react/src/ErrorBoundary.spec.tsx
+++ b/packages/react/src/ErrorBoundary.spec.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { type ComponentRef, createElement, createRef } from 'react'
 import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary'
@@ -13,10 +13,16 @@ import { SuspensiveError } from './models/SuspensiveError'
 import { CustomError, ERROR_MESSAGE, FALLBACK, TEXT, Throw } from './test-utils'
 
 describe('<ErrorBoundary/>', () => {
-  beforeEach(() => Throw.reset())
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Throw.reset()
+  })
+
+  afterEach(() => vi.useRealTimers())
 
   it('should show children if no error but if error in children, catch it and show fallback and call onError', async () => {
     const onError = vi.fn()
+
     render(
       <ErrorBoundary onError={onError} fallback={<>{FALLBACK}</>}>
         <Throw.Error message={ERROR_MESSAGE} after={100}>
@@ -24,10 +30,12 @@ describe('<ErrorBoundary/>', () => {
         </Throw.Error>
       </ErrorBoundary>
     )
+
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
     expect(screen.queryByText(FALLBACK)).not.toBeInTheDocument()
     expect(onError).toHaveBeenCalledTimes(0)
-    await waitFor(() => expect(screen.queryByText(FALLBACK)).toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText(FALLBACK)).toBeInTheDocument()
     expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
     expect(onError).toHaveBeenCalledTimes(1)
   })
@@ -40,9 +48,11 @@ describe('<ErrorBoundary/>', () => {
         </Throw.Error>
       </ErrorBoundary>
     )
+
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
     expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument()
-    await waitFor(() => expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument()
     expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
   })
 
@@ -58,21 +68,25 @@ describe('<ErrorBoundary/>', () => {
 
   it('should catch it even if thrown null', async () => {
     const onError = vi.fn()
+
     render(
       <ErrorBoundary onError={onError} fallback={<>{FALLBACK}</>}>
         <Throw.Null after={100}>{TEXT}</Throw.Null>
       </ErrorBoundary>
     )
+
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
     expect(screen.queryByText(FALLBACK)).not.toBeInTheDocument()
     expect(onError).toHaveBeenCalledTimes(0)
-    await waitFor(() => expect(screen.queryByText(FALLBACK)).toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText(FALLBACK)).toBeInTheDocument()
     expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
     expect(onError).toHaveBeenCalledTimes(1)
   })
 
   it('should be reset by items of resetKeys, and call onReset', async () => {
     const onReset = vi.fn()
+
     const { rerender } = render(
       <ErrorBoundary resetKeys={[0]} fallback={(props) => props.error.message} onReset={onReset}>
         <Throw.Error message={ERROR_MESSAGE} after={100}>
@@ -80,9 +94,11 @@ describe('<ErrorBoundary/>', () => {
         </Throw.Error>
       </ErrorBoundary>
     )
+
     expect(onReset).toHaveBeenCalledTimes(0)
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
-    await waitFor(() => expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument()
     expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(0)
     rerender(
@@ -98,6 +114,7 @@ describe('<ErrorBoundary/>', () => {
 
   it('should be reset by length of resetKeys, and call onReset', async () => {
     const onReset = vi.fn()
+
     const { rerender } = render(
       <ErrorBoundary resetKeys={[0]} fallback={(props) => props.error.message} onReset={onReset}>
         <Throw.Error message={ERROR_MESSAGE} after={100}>
@@ -105,9 +122,11 @@ describe('<ErrorBoundary/>', () => {
         </Throw.Error>
       </ErrorBoundary>
     )
+
     expect(onReset).toHaveBeenCalledTimes(0)
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
-    await waitFor(() => expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument()
     expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(0)
     rerender(
@@ -124,6 +143,7 @@ describe('<ErrorBoundary/>', () => {
   it('should be reset by render prop reset(), and call onReset', async () => {
     const onReset = vi.fn()
     const fallbackFn = vi.fn<(props: ErrorBoundaryFallbackProps) => undefined>()
+
     render(
       <ErrorBoundary fallback={fallbackFn} onReset={onReset}>
         <Throw.Error message={ERROR_MESSAGE} after={100}>
@@ -131,9 +151,11 @@ describe('<ErrorBoundary/>', () => {
         </Throw.Error>
       </ErrorBoundary>
     )
+
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
     expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument()
-    await waitFor(() => expect(screen.queryByText(TEXT)).not.toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(0)
     expect(fallbackFn).toHaveBeenCalled()
     act(() => fallbackFn.mock.calls[0][0].reset())
@@ -144,6 +166,7 @@ describe('<ErrorBoundary/>', () => {
 
   it('should be reset by ref.reset(), and call onReset', async () => {
     const onReset = vi.fn()
+
     // eslint-disable-next-line @eslint-react/no-create-ref
     const ref = createRef<ComponentRef<typeof ErrorBoundary>>()
     render(
@@ -156,7 +179,8 @@ describe('<ErrorBoundary/>', () => {
 
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
     expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument()
-    await waitFor(() => expect(screen.queryByText(TEXT)).not.toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(0)
     act(() => ref.current?.reset())
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
@@ -164,7 +188,7 @@ describe('<ErrorBoundary/>', () => {
     expect(onReset).toHaveBeenCalledTimes(1)
   })
 
-  it('should catch Error by many criteria', async () => {
+  it('should catch Error by many criteria', () => {
     const onErrorParent = vi.fn()
     const onErrorChild = vi.fn()
 
@@ -184,10 +208,10 @@ describe('<ErrorBoundary/>', () => {
 
     expect(onErrorChild).toBeCalledTimes(1)
     expect(onErrorParent).toBeCalledTimes(0)
-    await waitFor(() => expect(screen.queryByText(`${ERROR_MESSAGE} of Child`)).toBeInTheDocument())
+    expect(screen.queryByText(`${ERROR_MESSAGE} of Child`)).toBeInTheDocument()
   })
 
-  it('should re-throw error if not shouldCatch error in children without rendering fallback', async () => {
+  it('should re-throw error if not shouldCatch error in children without rendering fallback', () => {
     const onErrorParent = vi.fn()
     const onErrorChild = vi.fn()
     const Fallback = vi.fn()
@@ -204,7 +228,7 @@ describe('<ErrorBoundary/>', () => {
 
     expect(onErrorChild).toBeCalledTimes(0)
     expect(onErrorParent).toBeCalledTimes(1)
-    await waitFor(() => expect(screen.queryByText(`${ERROR_MESSAGE} of Parent`)).toBeInTheDocument())
+    expect(screen.queryByText(`${ERROR_MESSAGE} of Parent`)).toBeInTheDocument()
   })
 
   it.each([
@@ -222,7 +246,7 @@ describe('<ErrorBoundary/>', () => {
     },
   ])(
     'should catch Error by one criteria(ErrorConstructor)',
-    async ({ childCalledTimes, parentCalledTimes, shouldCatch, errorText }) => {
+    ({ childCalledTimes, parentCalledTimes, shouldCatch, errorText }) => {
       const onErrorParent = vi.fn()
       const onErrorChild = vi.fn()
 
@@ -242,7 +266,7 @@ describe('<ErrorBoundary/>', () => {
 
       expect(onErrorChild).toBeCalledTimes(childCalledTimes)
       expect(onErrorParent).toBeCalledTimes(parentCalledTimes)
-      await waitFor(() => expect(screen.queryByText(errorText)).toBeInTheDocument())
+      expect(screen.queryByText(errorText)).toBeInTheDocument()
     }
   )
 
@@ -261,7 +285,7 @@ describe('<ErrorBoundary/>', () => {
     },
   ])(
     'should catch Error by one criteria(ShouldCatchCallback)',
-    async ({ childCalledTimes, parentCalledTimes, shouldCatch, errorText }) => {
+    ({ childCalledTimes, parentCalledTimes, shouldCatch, errorText }) => {
       const onErrorParent = vi.fn()
       const onErrorChild = vi.fn()
 
@@ -281,7 +305,7 @@ describe('<ErrorBoundary/>', () => {
 
       expect(onErrorChild).toBeCalledTimes(childCalledTimes)
       expect(onErrorParent).toBeCalledTimes(parentCalledTimes)
-      await waitFor(() => expect(screen.queryByText(errorText)).toBeInTheDocument())
+      expect(screen.queryByText(errorText)).toBeInTheDocument()
     }
   )
 
@@ -290,7 +314,7 @@ describe('<ErrorBoundary/>', () => {
     { childCalledTimes: 1, parentCalledTimes: 0, shouldCatch: true, errorText: `${ERROR_MESSAGE} of Child` },
   ])(
     'should catch Error by one criteria(boolean)',
-    async ({ childCalledTimes, parentCalledTimes, errorText, shouldCatch }) => {
+    ({ childCalledTimes, parentCalledTimes, errorText, shouldCatch }) => {
       const onErrorParent = vi.fn()
       const onErrorChild = vi.fn()
 
@@ -310,7 +334,7 @@ describe('<ErrorBoundary/>', () => {
 
       expect(onErrorChild).toBeCalledTimes(childCalledTimes)
       expect(onErrorParent).toBeCalledTimes(parentCalledTimes)
-      await waitFor(() => expect(screen.queryByText(errorText)).toBeInTheDocument())
+      expect(screen.queryByText(errorText)).toBeInTheDocument()
     }
   )
 
@@ -332,8 +356,10 @@ describe('<ErrorBoundary/>', () => {
     )
 
     expect(screen.queryByText("ErrorBoundary's children before error")).toBeInTheDocument()
-    await waitFor(() => expect(screen.queryByText("ErrorBoundary's fallback before error")).toBeInTheDocument())
-    await waitFor(() => expect(screen.queryByText('This is expected')).toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText("ErrorBoundary's fallback before error")).toBeInTheDocument()
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText('This is expected')).toBeInTheDocument()
   })
 
   it('should not re-throw error in fallback (react-error-boundary)', async () => {
@@ -354,19 +380,17 @@ describe('<ErrorBoundary/>', () => {
     )
 
     expect(screen.queryByText("ErrorBoundary(react-error-boundary)'s children before error")).toBeInTheDocument()
-    await waitFor(() =>
-      expect(screen.queryByText("ErrorBoundary(react-error-boundary)'s fallback before error")).toBeInTheDocument()
-    )
-    await waitFor(() => expect(screen.queryByText('This is expected')).not.toBeInTheDocument())
-    await waitFor(() =>
-      expect(screen.queryByText("ErrorBoundary(react-error-boundary)'s fallback before error")).toBeInTheDocument()
-    )
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText("ErrorBoundary(react-error-boundary)'s fallback before error")).toBeInTheDocument()
+    expect(screen.queryByText('This is expected')).not.toBeInTheDocument()
+    expect(screen.queryByText("ErrorBoundary(react-error-boundary)'s fallback before error")).toBeInTheDocument()
   })
 })
 
 describe('<ErrorBoundary.Consumer/>', () => {
   it('should consume ErrorBoundaryContext like useErrorBoundary', async () => {
     const user = userEvent.setup()
+
     render(
       <ErrorBoundary fallback={({ error }) => <div>{error.message}</div>}>
         <ErrorBoundary.Consumer>
@@ -378,8 +402,9 @@ describe('<ErrorBoundary.Consumer/>', () => {
         </ErrorBoundary.Consumer>
       </ErrorBoundary>
     )
+
     await user.click(screen.getByRole('button'))
-    await waitFor(() => expect(screen.getByText(ERROR_MESSAGE)).toBeInTheDocument())
+    expect(screen.getByText(ERROR_MESSAGE)).toBeInTheDocument()
   })
 })
 
@@ -387,7 +412,10 @@ describe('useErrorBoundary', () => {
   beforeEach(() => Throw.reset())
 
   it('should supply setError to set Error of ErrorBoundary manually', async () => {
+    vi.useFakeTimers()
+
     const onError = vi.fn()
+
     render(
       <ErrorBoundary
         onError={onError}
@@ -408,10 +436,12 @@ describe('useErrorBoundary', () => {
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
     expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument()
     expect(onError).toHaveBeenCalledTimes(0)
-
-    await waitFor(() => expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument()
     expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
     expect(onError).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
   })
 
   it('should guarantee hook calling position is in children of ErrorBoundary', () => {
@@ -452,6 +482,8 @@ describe('useErrorBoundaryFallbackProps', () => {
   beforeEach(() => Throw.reset())
 
   it('should supply reset function and error to reset in fallback of ErrorBoundary', async () => {
+    vi.useFakeTimers()
+
     const onReset = vi.fn()
     render(
       <ErrorBoundary
@@ -468,17 +500,20 @@ describe('useErrorBoundaryFallbackProps', () => {
         </Throw.Error>
       </ErrorBoundary>
     )
+
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
     expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(0)
-
-    await waitFor(() => expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument()
     expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(0)
-
-    await waitFor(() => expect(screen.queryByText(TEXT)).toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText(TEXT)).toBeInTheDocument()
     expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
   })
 
   it('should guarantee hook calling position is in fallback of ErrorBoundary', () => {
@@ -538,15 +573,19 @@ describe('ErrorBoundary.with', () => {
 
   it("should render the wrapped component when there's no error", () => {
     render(createElement(ErrorBoundary.with({ fallback: (props) => <>{props.error.message}</> }, () => <>{TEXT}</>)))
+
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
   })
 
   it('should use default errorBoundaryProps when undefined is provided', () => {
     render(createElement(ErrorBoundary.with(undefined, () => <>{TEXT}</>)))
+
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
   })
 
   it('should render the fallback when there`s an error in the wrapped component', async () => {
+    vi.useFakeTimers()
+
     render(
       createElement(
         ErrorBoundary.with({ fallback: (props) => <>{props.error.message}</> }, () => (
@@ -556,13 +595,18 @@ describe('ErrorBoundary.with', () => {
         ))
       )
     )
+
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
-    await waitFor(() => expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument())
+    await act(() => vi.advanceTimersByTime(100))
+    expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument()
+
+    vi.useRealTimers()
   })
 
   it('should set displayName based on Component.displayName', () => {
     const Component = () => <></>
     Component.displayName = 'Custom'
+
     expect(ErrorBoundary.with({ fallback: () => <></> }, Component).displayName).toBe('ErrorBoundary.with(Custom)')
     expect(ErrorBoundary.with({ fallback: () => <></> }, () => <></>).displayName).toBe('ErrorBoundary.with(Component)')
   })

--- a/packages/react/src/ErrorBoundary.spec.tsx
+++ b/packages/react/src/ErrorBoundary.spec.tsx
@@ -101,6 +101,7 @@ describe('<ErrorBoundary/>', () => {
     expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument()
     expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(0)
+
     rerender(
       <ErrorBoundary resetKeys={[1]} fallback={(props) => props.error.message} onReset={onReset}>
         <Throw.Error message={ERROR_MESSAGE} after={100}>
@@ -108,6 +109,7 @@ describe('<ErrorBoundary/>', () => {
         </Throw.Error>
       </ErrorBoundary>
     )
+
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(1)
   })
@@ -129,6 +131,7 @@ describe('<ErrorBoundary/>', () => {
     expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument()
     expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(0)
+
     rerender(
       <ErrorBoundary resetKeys={[0, 1]} fallback={(props) => props.error.message} onReset={onReset}>
         <Throw.Error message={ERROR_MESSAGE} after={100}>
@@ -136,6 +139,7 @@ describe('<ErrorBoundary/>', () => {
         </Throw.Error>
       </ErrorBoundary>
     )
+
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(1)
   })
@@ -166,9 +170,9 @@ describe('<ErrorBoundary/>', () => {
 
   it('should be reset by ref.reset(), and call onReset', async () => {
     const onReset = vi.fn()
-
     // eslint-disable-next-line @eslint-react/no-create-ref
     const ref = createRef<ComponentRef<typeof ErrorBoundary>>()
+
     render(
       <ErrorBoundary ref={ref} fallback={(props) => <>{props.error.message}</>} onReset={onReset}>
         <Throw.Error message={ERROR_MESSAGE} after={100}>
@@ -409,11 +413,14 @@ describe('<ErrorBoundary.Consumer/>', () => {
 })
 
 describe('useErrorBoundary', () => {
-  beforeEach(() => Throw.reset())
+  beforeEach(() => vi.useFakeTimers())
+
+  afterEach(() => {
+    vi.useRealTimers()
+    Throw.reset()
+  })
 
   it('should supply setError to set Error of ErrorBoundary manually', async () => {
-    vi.useFakeTimers()
-
     const onError = vi.fn()
 
     render(
@@ -440,8 +447,6 @@ describe('useErrorBoundary', () => {
     expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument()
     expect(screen.queryByText(TEXT)).not.toBeInTheDocument()
     expect(onError).toHaveBeenCalledTimes(1)
-
-    vi.useRealTimers()
   })
 
   it('should guarantee hook calling position is in children of ErrorBoundary', () => {
@@ -479,12 +484,16 @@ describe('useErrorBoundary', () => {
 })
 
 describe('useErrorBoundaryFallbackProps', () => {
-  beforeEach(() => Throw.reset())
+  beforeEach(() => vi.useFakeTimers())
+
+  afterEach(() => {
+    vi.useRealTimers()
+    Throw.reset()
+  })
 
   it('should supply reset function and error to reset in fallback of ErrorBoundary', async () => {
-    vi.useFakeTimers()
-
     const onReset = vi.fn()
+
     render(
       <ErrorBoundary
         onReset={onReset}
@@ -512,12 +521,11 @@ describe('useErrorBoundaryFallbackProps', () => {
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
     expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument()
     expect(onReset).toHaveBeenCalledTimes(1)
-
-    vi.useRealTimers()
   })
 
   it('should guarantee hook calling position is in fallback of ErrorBoundary', () => {
     const inFallback = vi.fn()
+
     expect(() =>
       render(
         <ErrorBoundary
@@ -549,6 +557,7 @@ describe('useErrorBoundaryFallbackProps', () => {
 
   it("should be prevented to be called in children of ErrorBoundary (ErrorBoundary shouldn't catch SuspensiveError)", () => {
     const inFallback = vi.fn()
+
     expect(() =>
       render(
         <ErrorBoundary
@@ -569,7 +578,12 @@ describe('useErrorBoundaryFallbackProps', () => {
 })
 
 describe('ErrorBoundary.with', () => {
-  beforeEach(() => Throw.reset())
+  beforeEach(() => vi.useFakeTimers())
+
+  afterEach(() => {
+    vi.useRealTimers()
+    Throw.reset()
+  })
 
   it("should render the wrapped component when there's no error", () => {
     render(createElement(ErrorBoundary.with({ fallback: (props) => <>{props.error.message}</> }, () => <>{TEXT}</>)))
@@ -584,8 +598,6 @@ describe('ErrorBoundary.with', () => {
   })
 
   it('should render the fallback when there`s an error in the wrapped component', async () => {
-    vi.useFakeTimers()
-
     render(
       createElement(
         ErrorBoundary.with({ fallback: (props) => <>{props.error.message}</> }, () => (
@@ -599,8 +611,6 @@ describe('ErrorBoundary.with', () => {
     expect(screen.queryByText(TEXT)).toBeInTheDocument()
     await act(() => vi.advanceTimersByTime(100))
     expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument()
-
-    vi.useRealTimers()
   })
 
   it('should set displayName based on Component.displayName', () => {


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

* relate #1448 

## before

![image](https://github.com/user-attachments/assets/daf65cfb-9bb6-4a85-bc84-93d944028737)

## after

![image](https://github.com/user-attachments/assets/4c8b6306-a890-4261-8711-f75df9604cf0)

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
