### PR TITLE
fix(react-query): update peerDependency, @tanstack/react-query to version 4.40.0 and deprecate old options

### DIFF
--- a/.changeset/healthy-apricots-chew.md
+++ b/.changeset/healthy-apricots-chew.md
@@ -4,4 +4,4 @@
 "@suspensive/react-query": minor
 ---
 
-chore: update react-query dependencies to version 4.40.0 and deprecate old options
+fix(react-query): update peerDependency, @tanstack/react-query to version 4.40.0 and deprecate old options

--- a/.changeset/healthy-apricots-chew.md
+++ b/.changeset/healthy-apricots-chew.md
@@ -1,0 +1,7 @@
+---
+"@suspensive/react-query-4": minor
+"@suspensive/react-query-5": minor
+"@suspensive/react-query": minor
+---
+
+chore: update react-query dependencies to version 4.40.0 and deprecate old options

--- a/docs/suspensive.org/src/components/BubbleChart.tsx
+++ b/docs/suspensive.org/src/components/BubbleChart.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { ErrorBoundary, Suspense } from '@suspensive/react'
-import { SuspenseQuery, queryOptions } from '@suspensive/react-query-4'
+import { SuspenseQuery } from '@suspensive/react-query-4'
 import {
   QueryClient,
   QueryClientProvider,
   QueryErrorResetBoundary,
+  queryOptions,
 } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import * as d3 from 'd3'

--- a/packages/react-query-4/src/PrefetchQuery.test-d.tsx
+++ b/packages/react-query-4/src/PrefetchQuery.test-d.tsx
@@ -1,7 +1,7 @@
+import { queryOptions } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { describe, expectTypeOf, it } from 'vitest'
 import { PrefetchQuery } from './PrefetchQuery'
-import { queryOptions } from './queryOptions'
 import { queryFn, queryKey } from './test-utils'
 
 describe('<PrefetchQuery/>', () => {

--- a/packages/react-query-4/src/SuspenseQueries.test-d.tsx
+++ b/packages/react-query-4/src/SuspenseQueries.test-d.tsx
@@ -1,9 +1,8 @@
+import { type UseSuspenseQueryResult, queryOptions } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { describe, expectTypeOf, it } from 'vitest'
-import { queryOptions } from './queryOptions'
 import { SuspenseQueries } from './SuspenseQueries'
 import { queryFn, queryKey } from './test-utils'
-import type { UseSuspenseQueryResult } from './useSuspenseQuery'
 
 describe('<SuspenseQueries/>', () => {
   it('type check', () => {
@@ -27,7 +26,6 @@ describe('<SuspenseQueries/>', () => {
       <SuspenseQueries queries={[{ queryKey, queryFn }, queryOptions({ queryKey, queryFn })]}>
         {([
           query1,
-
           query2,
           // @ts-expect-error Tuple type '[UseSuspenseQueryResult<{ text: string; }, unknown>]' of length '1' has no element at index '2'.
           query3,

--- a/packages/react-query-4/src/SuspenseQueries.tsx
+++ b/packages/react-query-4/src/SuspenseQueries.tsx
@@ -1,5 +1,5 @@
+import { type SuspenseQueriesOptions, type SuspenseQueriesResults, useSuspenseQueries } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
-import { type SuspenseQueriesOptions, type SuspenseQueriesResults, useSuspenseQueries } from './useSuspenseQueries'
 
 /**
  * We provide these components to clearly express what causes suspense at the same depth.

--- a/packages/react-query-4/src/SuspenseQuery.test-d.tsx
+++ b/packages/react-query-4/src/SuspenseQuery.test-d.tsx
@@ -1,9 +1,8 @@
+import { type UseSuspenseQueryResult, queryOptions } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { describe, expectTypeOf, it } from 'vitest'
-import { queryOptions } from './queryOptions'
 import { SuspenseQuery } from './SuspenseQuery'
 import { queryFn, queryKey } from './test-utils'
-import type { UseSuspenseQueryResult } from './useSuspenseQuery'
 
 describe('<SuspenseQuery/>', () => {
   it('type check', () => {
@@ -72,7 +71,7 @@ describe('<SuspenseQuery/>', () => {
         {(query) => {
           expectTypeOf(query).toEqualTypeOf<UseSuspenseQueryResult<{ text: string }>>()
           expectTypeOf(query.data).toEqualTypeOf<{ text: string }>()
-          expectTypeOf(query.status).toEqualTypeOf<'success'>()
+          expectTypeOf(query.status).toEqualTypeOf<'success' | 'error'>()
           return <></>
         }}
       </SuspenseQuery>
@@ -82,7 +81,7 @@ describe('<SuspenseQuery/>', () => {
         {(selectedQuery) => {
           expectTypeOf(selectedQuery).toEqualTypeOf<UseSuspenseQueryResult<string>>()
           expectTypeOf(selectedQuery.data).toEqualTypeOf<string>()
-          expectTypeOf(selectedQuery.status).toEqualTypeOf<'success'>()
+          expectTypeOf(selectedQuery.status).toEqualTypeOf<'error' | 'success'>()
           return <></>
         }}
       </SuspenseQuery>
@@ -98,7 +97,7 @@ describe('<SuspenseQuery/>', () => {
         {(query) => {
           expectTypeOf(query).toEqualTypeOf<UseSuspenseQueryResult<{ text: string }>>()
           expectTypeOf(query.data).toEqualTypeOf<{ text: string }>()
-          expectTypeOf(query.status).toEqualTypeOf<'success'>()
+          expectTypeOf(query.status).toEqualTypeOf<'error' | 'success'>()
           return <></>
         }}
       </SuspenseQuery>
@@ -108,7 +107,7 @@ describe('<SuspenseQuery/>', () => {
         {(selectedQuery) => {
           expectTypeOf(selectedQuery).toEqualTypeOf<UseSuspenseQueryResult<string>>()
           expectTypeOf(selectedQuery.data).toEqualTypeOf<string>()
-          expectTypeOf(selectedQuery.status).toEqualTypeOf<'success'>()
+          expectTypeOf(selectedQuery.status).toEqualTypeOf<'error' | 'success'>()
           return <></>
         }}
       </SuspenseQuery>

--- a/packages/react-query-4/src/SuspenseQuery.tsx
+++ b/packages/react-query-4/src/SuspenseQuery.tsx
@@ -1,6 +1,10 @@
-import type { QueryKey } from '@tanstack/react-query'
+import {
+  type QueryKey,
+  type UseSuspenseQueryOptions,
+  type UseSuspenseQueryResult,
+  useSuspenseQuery,
+} from '@tanstack/react-query'
 import type { ReactNode } from 'react'
-import { type UseSuspenseQueryOptions, type UseSuspenseQueryResult, useSuspenseQuery } from './useSuspenseQuery'
 
 /**
  * We provide these components to clearly express what causes suspense at the same depth.

--- a/packages/react-query-4/src/infiniteQueryOptions.ts
+++ b/packages/react-query-4/src/infiniteQueryOptions.ts
@@ -1,6 +1,9 @@
 import type { InfiniteData, QueryKey, UseInfiniteQueryOptions } from '@tanstack/react-query'
 import type { OmitKeyof, RequiredKeyof } from './utility-types'
 
+/**
+ * @deprecated There is no `SelectedInfiniteOptions` in \@tanstack/react-query@^4.40.0.
+ */
 export type SelectedInfiniteOptions<
   TQueryFnData,
   TError = unknown,
@@ -27,6 +30,9 @@ export type SelectedInfiniteOptions<
   select: (data: InfiniteData<TQueryFnData>) => InfiniteData<TData>
 }
 
+/**
+ * @deprecated There is no `UnSelectedInfiniteOptions` in \@tanstack/react-query@^4.40.0.
+ */
 export type UnSelectedInfiniteOptions<
   TQueryFnData,
   TError = unknown,

--- a/packages/react-query-4/src/queryOptions.test-d.tsx
+++ b/packages/react-query-4/src/queryOptions.test-d.tsx
@@ -1,11 +1,17 @@
-import { type UseQueryResult, useQueries, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  type UseQueryResult,
+  type UseSuspenseQueryResult,
+  queryOptions,
+  useQueries,
+  useQuery,
+  useQueryClient,
+  useSuspenseQueries,
+  useSuspenseQuery,
+} from '@tanstack/react-query'
 import { describe, expectTypeOf, it } from 'vitest'
-import { queryOptions } from './queryOptions'
 import { SuspenseQuery } from './SuspenseQuery'
 import { queryKey } from './test-utils'
 import { usePrefetchQuery } from './usePrefetchQuery'
-import { useSuspenseQueries } from './useSuspenseQueries'
-import { type UseSuspenseQueryResult, useSuspenseQuery } from './useSuspenseQuery'
 
 const query = {
   options1: () =>
@@ -58,26 +64,30 @@ describe('queryOptions', () => {
     ))()
   })
   it('should be used with useQueries', () => {
-    const [query1, query2, query3] = useQueries({
+    const [
+      query1,
+      query2,
+      // query3
+    ] = useQueries({
       queries: [
         query.options1(),
         { ...query.options2() },
-        queryOptions({
-          queryKey: [...queryKey, 4] as const,
-          queryFn: () => Promise.resolve({ field: 'success' }),
-          select: (data) => {
-            expectTypeOf(data).toEqualTypeOf<{ field: string }>()
-            return data.field
-          },
-        }),
+        // queryOptions({
+        //   queryKey: [...queryKey, 4] as const,
+        //   queryFn: () => Promise.resolve({ field: 'success' }),
+        //   select: (data) => {
+        //     expectTypeOf(data).toEqualTypeOf<{ field: string }>()
+        //     return data.field
+        //   },
+        // }),
       ],
     })
     expectTypeOf(query1).toEqualTypeOf<UseQueryResult<{ field: string }>>()
     expectTypeOf(query1.data).toEqualTypeOf<{ field: string } | undefined>()
     expectTypeOf(query2).toEqualTypeOf<UseQueryResult<{ field: string }>>()
     expectTypeOf(query2.data).toEqualTypeOf<{ field: string } | undefined>()
-    expectTypeOf(query3).toEqualTypeOf<UseQueryResult<string>>()
-    expectTypeOf(query3.data).toEqualTypeOf<string | undefined>()
+    // expectTypeOf(query3).toEqualTypeOf<UseQueryResult<string>>()
+    // expectTypeOf(query3.data).toEqualTypeOf<string | undefined>()
   })
   it('should be used with useSuspenseQueries', () => {
     const [query1, query2, query3] = useSuspenseQueries({

--- a/packages/react-query-4/src/queryOptions.ts
+++ b/packages/react-query-4/src/queryOptions.ts
@@ -1,6 +1,9 @@
-import type { QueryKey, UseQueryOptions } from '@tanstack/react-query'
+import { type QueryKey, type UseQueryOptions, queryOptions as original_queryOptions } from '@tanstack/react-query'
 import type { OmitKeyof, RequiredKeyof } from './utility-types'
 
+/**
+ * @deprecated There is no `SelectedQueryOptions` in \@tanstack/react-query@^4.40.0.
+ */
 export type SelectedQueryOptions<
   TQueryFnData = unknown,
   TError = unknown,
@@ -29,6 +32,9 @@ export type SelectedQueryOptions<
   select: (data: TQueryFnData) => TData
 }
 
+/**
+ * @deprecated There is no `UnSelectedQueryOptions` in \@tanstack/react-query@^4.40.0.
+ */
 export type UnSelectedQueryOptions<
   TQueryFnData = unknown,
   TError = unknown,
@@ -58,29 +64,12 @@ export type UnSelectedQueryOptions<
 }
 
 /**
- * Creates a reusable query options object that can be used across different query hooks.
- * Provides better type inference and easier query key management.
- *
- * @see {@link https://suspensive.org/docs/react-query/queryOptions Suspensive Docs}
+ * This feature is officially supported in \@tanstack/react-query@^4.40.0, You can proceed with the migration.
+ * @deprecated Use `queryOptions` from \@tanstack/react-query@^4.40.0
+ * @example
+ * ```diff
+ * - import { queryOptions } from '@suspensive/react-query'
+ * + import { queryOptions } from '@tanstack/react-query'
+ * ```
  */
-export function queryOptions<
-  TQueryFnData = unknown,
-  TError = unknown,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
->(
-  options: SelectedQueryOptions<TQueryFnData, TError, TData, TQueryKey>
-): SelectedQueryOptions<TQueryFnData, TError, TData, TQueryKey>
-
-export function queryOptions<
-  TQueryFnData = unknown,
-  TError = unknown,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
->(
-  options: UnSelectedQueryOptions<TQueryFnData, TError, TData, TQueryKey>
-): UnSelectedQueryOptions<TQueryFnData, TError, TData, TQueryKey>
-
-export function queryOptions(options: unknown) {
-  return options
-}
+export const queryOptions = original_queryOptions

--- a/packages/react-query-4/src/usePrefetchQuery.test-d.tsx
+++ b/packages/react-query-4/src/usePrefetchQuery.test-d.tsx
@@ -1,4 +1,4 @@
-import { queryOptions } from './queryOptions'
+import { queryOptions } from '@tanstack/react-query'
 import { queryFn, queryKey } from './test-utils'
 import { usePrefetchQuery } from './usePrefetchQuery'
 

--- a/packages/react-query-4/src/useSuspenseQueries.test-d.ts
+++ b/packages/react-query-4/src/useSuspenseQueries.test-d.ts
@@ -1,8 +1,6 @@
+import { type UseSuspenseQueryResult, queryOptions, useSuspenseQueries } from '@tanstack/react-query'
 import { describe, expectTypeOf, it } from 'vitest'
-import { queryOptions } from './queryOptions'
 import { queryFn, queryKey, select } from './test-utils'
-import { useSuspenseQueries } from './useSuspenseQueries'
-import type { UseSuspenseQueryResult } from './useSuspenseQuery'
 
 describe('useSuspenseQueries', () => {
   it('type check', () => {
@@ -66,15 +64,15 @@ describe('useSuspenseQueries', () => {
     })
 
     expectTypeOf(query).toEqualTypeOf<UseSuspenseQueryResult<{ text: string }>>()
-    expectTypeOf(query.status).toEqualTypeOf<`success`>()
+    expectTypeOf(query.status).toEqualTypeOf<'error' | 'success'>()
     expectTypeOf(query.data).toEqualTypeOf<{ text: string }>()
 
     expectTypeOf(selectedQuery).toEqualTypeOf<UseSuspenseQueryResult<string>>()
-    expectTypeOf(selectedQuery.status).toEqualTypeOf<`success`>()
+    expectTypeOf(selectedQuery.status).toEqualTypeOf<'error' | 'success'>()
     expectTypeOf(selectedQuery.data).toEqualTypeOf<string>()
 
     expectTypeOf(selectedQueryByQueryOptions).toEqualTypeOf<UseSuspenseQueryResult<string>>()
-    expectTypeOf(selectedQueryByQueryOptions.status).toEqualTypeOf<`success`>()
+    expectTypeOf(selectedQueryByQueryOptions.status).toEqualTypeOf<'error' | 'success'>()
     expectTypeOf(selectedQueryByQueryOptions.data).toEqualTypeOf<string>()
   })
 })

--- a/packages/react-query-4/src/useSuspenseQueries.ts
+++ b/packages/react-query-4/src/useSuspenseQueries.ts
@@ -1,131 +1,46 @@
-import { type QueryFunction, type UseQueryOptions, useQueries } from '@tanstack/react-query'
-import type { UseSuspenseQueryOptions, UseSuspenseQueryResult } from './useSuspenseQuery'
-
-// Avoid TS depth-limit error in case of large array literal
-type MAXIMUM_DEPTH = 20
-
-type GetSuspenseOptions<T> =
-  // Part 1: responsible for applying explicit type parameter to function arguments, if object { queryFnData: TQueryFnData, error: TError, data: TData }
-  T extends {
-    queryFnData: infer TQueryFnData
-    error?: infer TError
-    data: infer TData
-  }
-    ? UseSuspenseQueryOptions<TQueryFnData, TError, TData>
-    : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
-      ? UseSuspenseQueryOptions<TQueryFnData, TError>
-      : T extends { data: infer TData; error?: infer TError }
-        ? UseSuspenseQueryOptions<unknown, TError, TData>
-        : // Part 2: responsible for applying explicit type parameter to function arguments, if tuple [TQueryFnData, TError, TData]
-          T extends [infer TQueryFnData, infer TError, infer TData]
-          ? UseSuspenseQueryOptions<TQueryFnData, TError, TData>
-          : T extends [infer TQueryFnData, infer TError]
-            ? UseSuspenseQueryOptions<TQueryFnData, TError>
-            : T extends [infer TQueryFnData]
-              ? UseSuspenseQueryOptions<TQueryFnData>
-              : // Part 3: responsible for inferring and enforcing type if no explicit parameter was provided
-                T extends {
-                    queryFn?: QueryFunction<infer TQueryFnData, infer TQueryKey>
-                    select?: (data: any) => infer TData
-                  }
-                ? UseSuspenseQueryOptions<TQueryFnData, unknown, TData, TQueryKey>
-                : T extends {
-                      queryFn?: QueryFunction<infer TQueryFnData, infer TQueryKey>
-                    }
-                  ? UseSuspenseQueryOptions<TQueryFnData, unknown, TQueryFnData, TQueryKey>
-                  : // Fallback
-                    UseSuspenseQueryOptions
-
-type GetSuspenseResults<T> =
-  // Part 1: responsible for mapping explicit type parameter to function result, if object
-  T extends { queryFnData: any; error?: infer TError; data: infer TData }
-    ? UseSuspenseQueryResult<TData, TError>
-    : T extends { queryFnData: infer TQueryFnData; error?: infer TError }
-      ? UseSuspenseQueryResult<TQueryFnData, TError>
-      : T extends { data: infer TData; error?: infer TError }
-        ? UseSuspenseQueryResult<TData, TError>
-        : // Part 2: responsible for mapping explicit type parameter to function result, if tuple
-          T extends [any, infer TError, infer TData]
-          ? UseSuspenseQueryResult<TData, TError>
-          : T extends [infer TQueryFnData, infer TError]
-            ? UseSuspenseQueryResult<TQueryFnData, TError>
-            : T extends [infer TQueryFnData]
-              ? UseSuspenseQueryResult<TQueryFnData>
-              : // Part 3: responsible for mapping inferred type to results, if no explicit parameter was provided
-                T extends {
-                    queryFn?: QueryFunction<infer TQueryFnData, any>
-                    select?: (data: any) => infer TData
-                  }
-                ? UseSuspenseQueryResult<unknown extends TData ? TQueryFnData : TData>
-                : T extends {
-                      queryFn?: QueryFunction<infer TQueryFnData, any>
-                    }
-                  ? UseSuspenseQueryResult<TQueryFnData>
-                  : // Fallback
-                    UseSuspenseQueryResult
+import {
+  type SuspenseQueriesOptions as original_SuspenseQueriesOptions,
+  type SuspenseQueriesResults as original_SuspenseQueriesResults,
+  useSuspenseQueries as original_useSuspenseQueries,
+} from '@tanstack/react-query'
 
 /**
- * SuspenseQueriesOptions reducer recursively unwraps function arguments to infer/enforce type param
+ * This feature is officially supported in \@tanstack/react-query@^4.40.0, You can proceed with the migration.
+ * @deprecated Use `SuspenseQueriesOptions` from \@tanstack/react-query@^4.40.0
+ * @example
+ * ```diff
+ * - import type { SuspenseQueriesOptions } from '@suspensive/react-query'
+ * + import type { SuspenseQueriesOptions } from '@tanstack/react-query'
+ * ```
  */
 export type SuspenseQueriesOptions<
   T extends Array<any>,
   TResult extends Array<any> = [],
   TDepth extends ReadonlyArray<number> = [],
-> = TDepth['length'] extends MAXIMUM_DEPTH
-  ? Array<UseSuspenseQueryOptions>
-  : T extends []
-    ? []
-    : T extends [infer Head]
-      ? [...TResult, GetSuspenseOptions<Head>]
-      : T extends [infer Head, ...infer Tail]
-        ? SuspenseQueriesOptions<[...Tail], [...TResult, GetSuspenseOptions<Head>], [...TDepth, 1]>
-        : Array<unknown> extends T
-          ? T
-          : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
-            // use this to infer the param types in the case of Array.map() argument
-            T extends Array<UseSuspenseQueryOptions<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>>
-            ? Array<UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>>
-            : // Fallback
-              Array<UseSuspenseQueryOptions>
+> = original_SuspenseQueriesOptions<T, TResult, TDepth>
 
 /**
- * SuspenseQueriesResults reducer recursively maps type param to results
+ * This feature is officially supported in \@tanstack/react-query@^4.40.0, You can proceed with the migration.
+ * @deprecated Use `SuspenseQueriesResults` from \@tanstack/react-query@^4.40.0
+ * @example
+ * ```diff
+ * - import type { SuspenseQueriesResults } from '@suspensive/react-query'
+ * + import type { SuspenseQueriesResults } from '@tanstack/react-query'
+ * ```
  */
 export type SuspenseQueriesResults<
   T extends Array<any>,
   TResult extends Array<any> = [],
   TDepth extends ReadonlyArray<number> = [],
-> = TDepth['length'] extends MAXIMUM_DEPTH
-  ? Array<UseSuspenseQueryResult>
-  : T extends []
-    ? []
-    : T extends [infer Head]
-      ? [...TResult, GetSuspenseResults<Head>]
-      : T extends [infer Head, ...infer Tail]
-        ? SuspenseQueriesResults<[...Tail], [...TResult, GetSuspenseResults<Head>], [...TDepth, 1]>
-        : T extends Array<UseSuspenseQueryOptions<infer TQueryFnData, infer TError, infer TData, any>>
-          ? // Dynamic-size (homogenous) UseQueryOptions array: map directly to array of results
-            Array<UseSuspenseQueryResult<unknown extends TData ? TQueryFnData : TData, TError>>
-          : // Fallback
-            Array<UseSuspenseQueryResult>
+> = original_SuspenseQueriesResults<T, TResult, TDepth>
 
 /**
- * This hook is wrapping `useQueries` of `@tanstack/react-query` v4 with default suspense option.
- * @see {@link https://suspensive.org/docs/react-query/useSuspenseQueries Suspensive Docs}
+ * This feature is officially supported in \@tanstack/react-query@^4.40.0, You can proceed with the migration.
+ * @deprecated Use `useSuspenseQueries` from \@tanstack/react-query@^4.40.0
+ * @example
+ * ```diff
+ * - import { useSuspenseQueries } from '@suspensive/react-query'
+ * + import { useSuspenseQueries } from '@tanstack/react-query'
+ * ```
  */
-export function useSuspenseQueries<T extends any[]>({
-  queries,
-  context,
-}: {
-  queries: readonly [...SuspenseQueriesOptions<T>]
-  context?: UseQueryOptions['context']
-}): SuspenseQueriesResults<T> {
-  return useQueries({
-    queries: queries.map((query: typeof queries) => ({
-      // eslint-disable-next-line @typescript-eslint/no-misused-spread
-      ...query,
-      suspense: true,
-    })),
-    context,
-  }) as SuspenseQueriesResults<T>
-}
+export const useSuspenseQueries = original_useSuspenseQueries

--- a/packages/react-query-4/src/useSuspenseQuery.test-d.ts
+++ b/packages/react-query-4/src/useSuspenseQuery.test-d.ts
@@ -1,7 +1,6 @@
+import { type UseSuspenseQueryResult, queryOptions, useSuspenseQuery } from '@tanstack/react-query'
 import { describe, expectTypeOf, it } from 'vitest'
-import { queryOptions } from './queryOptions'
 import { queryFn, queryKey } from './test-utils'
-import { type UseSuspenseQueryResult, useSuspenseQuery } from './useSuspenseQuery'
 
 describe('useSuspenseQuery', () => {
   it('type check', () => {
@@ -47,12 +46,12 @@ describe('useSuspenseQuery', () => {
     const result = useSuspenseQuery({ queryKey, queryFn })
     expectTypeOf(result).toEqualTypeOf<UseSuspenseQueryResult<{ text: string }>>()
     expectTypeOf(result.data).toEqualTypeOf<{ text: string }>()
-    expectTypeOf(result.status).toEqualTypeOf<'success'>()
+    expectTypeOf(result.status).toEqualTypeOf<'error' | 'success'>()
 
     const selectedResult = useSuspenseQuery({ queryKey, queryFn, select: (data) => data.text })
     expectTypeOf(selectedResult).toEqualTypeOf<UseSuspenseQueryResult<string>>()
     expectTypeOf(selectedResult.data).toEqualTypeOf<string>()
-    expectTypeOf(selectedResult.status).toEqualTypeOf<'success'>()
+    expectTypeOf(selectedResult.status).toEqualTypeOf<'error' | 'success'>()
 
     const options = queryOptions({
       queryKey,
@@ -62,7 +61,7 @@ describe('useSuspenseQuery', () => {
     const resultWithOptions = useSuspenseQuery(options)
     expectTypeOf(resultWithOptions).toEqualTypeOf<UseSuspenseQueryResult<{ text: string }>>()
     expectTypeOf(resultWithOptions.data).toEqualTypeOf<{ text: string }>()
-    expectTypeOf(resultWithOptions.status).toEqualTypeOf<'success'>()
+    expectTypeOf(resultWithOptions.status).toEqualTypeOf<'error' | 'success'>()
 
     const selectedResultWithOptions = useSuspenseQuery({
       ...options,
@@ -70,6 +69,6 @@ describe('useSuspenseQuery', () => {
     })
     expectTypeOf(selectedResultWithOptions).toEqualTypeOf<UseSuspenseQueryResult<string>>()
     expectTypeOf(selectedResultWithOptions.data).toEqualTypeOf<string>()
-    expectTypeOf(selectedResultWithOptions.status).toEqualTypeOf<'success'>()
+    expectTypeOf(selectedResultWithOptions.status).toEqualTypeOf<'error' | 'success'>()
   })
 })

--- a/packages/react-query-4/src/useSuspenseQuery.ts
+++ b/packages/react-query-4/src/useSuspenseQuery.ts
@@ -1,37 +1,38 @@
-import { type QueryKey, type UseQueryOptions, type UseQueryResult, useQuery } from '@tanstack/react-query'
-import type { OmitKeyof } from './utility-types'
-
-export interface UseSuspenseQueryResult<TData = unknown, TError = unknown>
-  extends OmitKeyof<UseQueryResult<TData, TError>, keyof Pick<UseQueryResult, 'isPlaceholderData'>> {
-  data: TData
-  status: 'success'
-}
-
-export type UseSuspenseQueryOptions<
-  TQueryFnData = unknown,
-  TError = unknown,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
-> = OmitKeyof<
-  UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  'suspense' | 'useErrorBoundary' | 'enabled' | 'placeholderData' | 'networkMode'
->
+import {
+  type UseSuspenseQueryOptions as original_UseSuspenseQueryOptions,
+  type UseSuspenseQueryResult as original_UseSuspenseQueryResult,
+  useSuspenseQuery as original_useSuspenseQuery,
+} from '@tanstack/react-query'
 
 /**
- * This hook is wrapping `useQuery` of `@tanstack/react-query` v4 with default suspense option.
- * @see {@link https://suspensive.org/docs/react-query/useSuspenseQuery Suspensive Docs}
+ * This feature is officially supported in \@tanstack/react-query@^4.40.0, You can proceed with the migration.
+ * @deprecated Use `UseSuspenseQueryOptions` from \@tanstack/react-query@^4.40.0
+ * @example
+ * ```diff
+ * - import type { UseSuspenseQueryOptions } from '@suspensive/react-query'
+ * + import type { UseSuspenseQueryOptions } from '@tanstack/react-query'
+ * ```
  */
-export function useSuspenseQuery<
-  TQueryFnData = unknown,
-  TError = unknown,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
->(options: UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>) {
-  return useQuery<TQueryFnData, TError, TData, TQueryKey>({
-    ...options,
-    enabled: true,
-    useErrorBoundary: true,
-    suspense: true,
-    networkMode: 'always',
-  }) as UseSuspenseQueryResult<TData, TError>
-}
+export type UseSuspenseQueryOptions = original_UseSuspenseQueryOptions
+
+/**
+ * This feature is officially supported in \@tanstack/react-query@^4.40.0, You can proceed with the migration.
+ * @deprecated Use `UseSuspenseQueryResult` from \@tanstack/react-query@^4.40.0
+ * @example
+ * ```diff
+ * - import type { UseSuspenseQueryResult } from '@suspensive/react-query'
+ * + import type { UseSuspenseQueryResult } from '@tanstack/react-query'
+ * ```
+ */
+export type UseSuspenseQueryResult = original_UseSuspenseQueryResult
+
+/**
+ * This feature is officially supported in \@tanstack/react-query@^4.40.0, You can proceed with the migration.
+ * @deprecated Use `useSuspenseQuery` from \@tanstack/react-query@^4.40.0
+ * @example
+ * ```diff
+ * - import { useSuspenseQuery } from '@suspensive/react-query'
+ * + import { useSuspenseQuery } from '@tanstack/react-query'
+ * ```
+ */
+export const useSuspenseQuery = original_useSuspenseQuery

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -69,7 +69,7 @@
     "react": "catalog:react19"
   },
   "peerDependencies": {
-    "@tanstack/react-query": "^4 || ^5",
+    "@tanstack/react-query": "^4.40.0 || ^5",
     "react": "^18 || ^19"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,103 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@next/eslint-plugin-next':
+      specifier: ^15.3.3
+      version: 15.3.3
+    '@next/third-parties':
+      specifier: ^15.3.3
+      version: 15.3.3
+    '@tailwindcss/postcss':
+      specifier: ^4.1.8
+      version: 4.1.8
+    babel-jest:
+      specifier: ^29.7.0
+      version: 29.7.0
+    clsx:
+      specifier: ^2.1.1
+      version: 2.1.1
+    jest:
+      specifier: ^29.7.0
+      version: 29.7.0
+    next:
+      specifier: ^15.3.3
+      version: 15.3.3
+    prettier-plugin-tailwindcss:
+      specifier: ^0.6.12
+      version: 0.6.12
+    sharp:
+      specifier: ^0.34.2
+      version: 0.34.2
+    tailwindcss:
+      specifier: ^4.1.8
+      version: 4.1.8
+  react-query4:
+    '@tanstack/react-query':
+      specifier: 4.40.0
+      version: 4.40.0
+    '@tanstack/react-query-devtools':
+      specifier: 4.40.0
+      version: 4.40.0
+  react-query5:
+    '@tanstack/react-query':
+      specifier: ^5.79.0
+      version: 5.79.0
+    '@tanstack/react-query-devtools':
+      specifier: ^5.79.0
+      version: 5.79.0
+    '@tanstack/react-query-next-experimental':
+      specifier: ^5.79.0
+      version: 5.79.0
+  react18:
+    '@types/react':
+      specifier: 18.3.12
+      version: 18.3.12
+    '@types/react-dom':
+      specifier: 18.3.1
+      version: 18.3.1
+    react:
+      specifier: 18.3.1
+      version: 18.3.1
+    react-dom:
+      specifier: 18.3.1
+      version: 18.3.1
+  react19:
+    '@react-navigation/native':
+      specifier: ^7.0.14
+      version: 7.0.14
+    '@testing-library/react-native':
+      specifier: ^12.9.0
+      version: 12.9.0
+    '@types/react':
+      specifier: ^19.1.6
+      version: 19.1.6
+    '@types/react-dom':
+      specifier: ^19.1.2
+      version: 19.1.2
+    expo:
+      specifier: ^52.0.24
+      version: 52.0.24
+    expo-router:
+      specifier: ^4.0.16
+      version: 4.0.16
+    jest-expo:
+      specifier: ^52.0.2
+      version: 52.0.2
+    react:
+      specifier: ^19.1.0
+      version: 19.1.0
+    react-dom:
+      specifier: ^19.1.0
+      version: 19.1.0
+    react-native:
+      specifier: ^0.76.6
+      version: 0.76.6
+    react-native-web:
+      specifier: ^0.19.13
+      version: 0.19.13
+
 importers:
 
   .:
@@ -159,10 +256,10 @@ importers:
         version: link:../../packages/react-query-4
       '@tanstack/react-query':
         specifier: catalog:react-query4
-        version: 4.39.1(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)
+        version: 4.40.0(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)
       '@tanstack/react-query-devtools':
         specifier: catalog:react-query4
-        version: 4.39.1(@tanstack/react-query@4.39.1(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.40.0(@tanstack/react-query@4.40.0(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -587,7 +684,7 @@ importers:
         specifier: workspace:^3.2.3
         version: link:../react-query-5
       '@tanstack/react-query':
-        specifier: ^4 || ^5
+        specifier: ^4.40.0 || ^5
         version: 5.79.0(react@19.1.0)
       cli-table3:
         specifier: ^0.6.5
@@ -625,7 +722,7 @@ importers:
         version: link:../../configs/tsup
       '@tanstack/react-query':
         specifier: catalog:react-query4
-        version: 4.39.1(react-dom@18.3.1(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)
+        version: 4.40.0(react-dom@18.3.1(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)
       '@types/react':
         specifier: catalog:react19
         version: 19.1.6
@@ -2104,7 +2201,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.8':
     resolution: {integrity: sha512-MpHrfPKcHL+b1wwx+WiniEL5n33tl964tN8EW1K4okW3/tAPgbu3R00NZs6OExH9PZGQP8OKhCXhZttbK2jUnA==}
@@ -2263,72 +2360,85 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.2':
     resolution: {integrity: sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.2':
     resolution: {integrity: sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.2':
     resolution: {integrity: sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.2':
     resolution: {integrity: sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.2':
     resolution: {integrity: sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.2':
     resolution: {integrity: sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.2':
     resolution: {integrity: sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==}
@@ -2569,36 +2679,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-arm64-musl@0.1.19':
     resolution: {integrity: sha512-OwTRF+H4IZYxmDFRi1IrLMfqbdIpvHeYbJl2X94NVsLVOY+3NUHvEzL3fYaVx5urBaMnIK0DD3wZLbcueWvxbA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/simple-git-linux-powerpc64le-gnu@0.1.19':
     resolution: {integrity: sha512-p7zuNNVyzpRvkCt2RIGv9FX/WPcPbZ6/FRUgUTZkA2WU33mrbvNqSi4AOqCCl6mBvEd+EOw5NU4lS9ORRJvAEg==}
     engines: {node: '>= 10'}
     cpu: [powerpc64le]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-s390x-gnu@0.1.19':
     resolution: {integrity: sha512-6N2vwJUPLiak8GLrS0a3is0gSb0UwI2CHOOqtvQxPmv+JVI8kn3vKiUscsktdDb0wGEPeZ8PvZs0y8UWix7K4g==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-x64-gnu@0.1.19':
     resolution: {integrity: sha512-61YfeO1J13WK7MalLgP3QlV6of2rWnVw1aqxWkAgy/lGxoOFSJ4Wid6ANVCEZk4tJpPX/XNeneqkUz5xpeb2Cw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-x64-musl@0.1.19':
     resolution: {integrity: sha512-cCTWNpMJnN3PrUBItWcs3dQKCydsIasbrS3laMzq8k7OzF93Zrp2LWDTPlLCO9brbBVpBzy2Qk5Xg9uAfe/Ukw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/simple-git-win32-arm64-msvc@0.1.19':
     resolution: {integrity: sha512-sWavb1BjeLKKBA+PbTsRSSzVNfb7V/dOpaJvkgR5d2kWFn/AHmCZHSSj/3nyZdYf0BdDC+DIvqk3daAEZ6QMVw==}
@@ -2642,24 +2758,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.3.3':
     resolution: {integrity: sha512-h6Y1fLU4RWAp1HPNJWDYBQ+e3G7sLckyBXhmH9ajn8l/RSMnhbuPBV/fXmy3muMcVwoJdHL+UtzRzs0nXOf9SA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.3.3':
     resolution: {integrity: sha512-jJ8HRiF3N8Zw6hGlytCj5BiHyG/K+fnTKVDEKvUCyiQ/0r5tgwO7OgaRiOjjRoIx2vwLR+Rz8hQoPrnmFbJdfw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.3.3':
     resolution: {integrity: sha512-HrUcTr4N+RgiiGn3jjeT6Oo208UT/7BuTr7K0mdKRBtTbT4v9zJqCDKO97DUqqoBK1qyzP1RwvrWTvU6EPh/Cw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.3.3':
     resolution: {integrity: sha512-SxorONgi6K7ZUysMtRF3mIeHC5aA3IQLmKFQzU0OuhuUYwpOBc1ypaLJLP5Bf3M9k53KUUUj4vTPwzGvl/NwlQ==}
@@ -2752,31 +2872,37 @@ packages:
     resolution: {integrity: sha512-RGFW4vCfKMFEIzb9VCY0oWyyY9tR1/o+wDdNePhiUXZU4SVniRPQaZ1SJ0sUFI1k25pXZmzQmIP6cBmazi/Dew==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@9.0.2':
     resolution: {integrity: sha512-lxx/PibBfzqYvut2Y8N2D0Ritg9H8pKO+7NUSJb9YjR/bfk2KRmP8iaUz3zB0JhPtf/W3REs65oKpWxgflGToA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@9.0.2':
     resolution: {integrity: sha512-yD28ptS/OuNhwkpXRPNf+/FvrO7lwURLsEbRVcL1kIE0GxNJNMtKgIE4xQvtKDzkhk6ZRpLho5VSrkkF+3ARTQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-s390x-gnu@9.0.2':
     resolution: {integrity: sha512-WBwEJdspoga2w+aly6JVZeHnxuPVuztw3fPfWrei2P6rNM5hcKxBGWKKT6zO1fPMCB4sdDkFohGKkMHVV1eryQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@9.0.2':
     resolution: {integrity: sha512-a2z3/cbOOTUq0UTBG8f3EO/usFcdwwXnCejfXv42HmV/G8GjrT4fp5+5mVDoMByH3Ce3iVPxj1LmS6OvItKMYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@9.0.2':
     resolution: {integrity: sha512-bHZF+WShYQWpuswB9fyxcgMIWVk4sZQT0wnwpnZgQuvGTZLkYJ1JTCXJMtaX5mIFHf69ngvawnwPIUA4Feil0g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-wasm32-wasi@9.0.2':
     resolution: {integrity: sha512-I5cSgCCh5nFozGSHz+PjIOfrqW99eUszlxKLgoNNzQ1xQ2ou9ZJGzcZ94BHsM9SpyYHLtgHljmOZxCT9bgxYNA==}
@@ -3117,51 +3243,61 @@ packages:
     resolution: {integrity: sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.9':
     resolution: {integrity: sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.34.9':
     resolution: {integrity: sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.34.9':
     resolution: {integrity: sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.9':
     resolution: {integrity: sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.9':
     resolution: {integrity: sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.9':
     resolution: {integrity: sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.34.9':
     resolution: {integrity: sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.34.9':
     resolution: {integrity: sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.34.9':
     resolution: {integrity: sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.34.9':
     resolution: {integrity: sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==}
@@ -3268,24 +3404,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.8':
     resolution: {integrity: sha512-O6b8QesPbJCRshsNApsOIpzKt3ztG35gfX9tEf4arD7mwNinsoCKxkj8TgEE0YRjmjtO3r9FlJnT/ENd9EVefQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.8':
     resolution: {integrity: sha512-32iEXX/pXwikshNOGnERAFwFSfiltmijMIAbUhnNyjFr3tmWmMJWQKU2vNcFX0DACSXJ3ZWcSkzNbaKTdngH6g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.8':
     resolution: {integrity: sha512-s+VSSD+TfZeMEsCaFaHTaY5YNj3Dri8rST09gMvYQKwPphacRG7wbuQ5ZJMIJXN/puxPcg/nU+ucvWguPpvBDg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.8':
     resolution: {integrity: sha512-CXBPVFkpDjM67sS1psWohZ6g/2/cd+cq56vPxK4JeawelxwK4YECgl9Y9TjkE2qfF+9/s1tHHJqrC4SS6cVvSg==}
@@ -3322,8 +3462,8 @@ packages:
     resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
     engines: {node: '>=12'}
 
-  '@tanstack/query-core@4.39.1':
-    resolution: {integrity: sha512-E1g5oEiBq8l1xU1ELXieEBD55oZQscn4kaHidsxdCH1egAk9Tx4sTi8rgQiayoaEWESOurRdDEf2wJHp9/BRDg==}
+  '@tanstack/query-core@4.40.0':
+    resolution: {integrity: sha512-7MJTtZkCSuehMC7IxMOCGsLvHS3jHx4WjveSrGsG1Nc1UQLjaFwwkpLA2LmPfvOAxnH4mszMOBFD6LlZE+aB+Q==}
 
   '@tanstack/query-core@5.79.0':
     resolution: {integrity: sha512-s+epTqqLM0/TbJzMAK7OEhZIzh63P9sWz5HEFc5XHL4FvKQXQkcjI8F3nee+H/xVVn7mrP610nVXwOytTSYd0w==}
@@ -3331,10 +3471,10 @@ packages:
   '@tanstack/query-devtools@5.76.0':
     resolution: {integrity: sha512-1p92nqOBPYVqVDU0Ua5nzHenC6EGZNrLnB2OZphYw8CNA1exuvI97FVgIKON7Uug3uQqvH/QY8suUKpQo8qHNQ==}
 
-  '@tanstack/react-query-devtools@4.39.1':
-    resolution: {integrity: sha512-Sv1RdoM6jGpXzvCtHNMBh6Fi9WVpSNap9NS+KUhVt+iPdV9exS5cNna4EjyvLWQ4fIKv/y67M9zStxlq1WV3bw==}
+  '@tanstack/react-query-devtools@4.40.0':
+    resolution: {integrity: sha512-Imtu6sx1NDVtH+hVuF7ftTL3t9r7jmfgnfedoj9xuxsFYwC2IbD0wXKJbeItHa4XbXCd63BFRGGGrMtVzuMnbA==}
     peerDependencies:
-      '@tanstack/react-query': ^4.39.1
+      '@tanstack/react-query': ^4.40.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
 
@@ -3351,8 +3491,8 @@ packages:
       next: ^13 || ^14 || ^15
       react: ^18 || ^19
 
-  '@tanstack/react-query@4.39.1':
-    resolution: {integrity: sha512-eV8PchGpgqE5OMQ5LEfYmgwdKI3uZLSXekfkCpqvLNExE1bDFsPL1zFlFid5CSe7gf2zGju00PnsBoJcEBUJMw==}
+  '@tanstack/react-query@4.40.0':
+    resolution: {integrity: sha512-kt1G/wETT/Ad79cac5zJ8tyaMOm4rgyeomW5yDxgOO9qEhOwufgw9kgPpp+T9U0M0lL7EMoc6YXgv4gYhXu9tg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -7173,48 +7313,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.30.1:
     resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.27.0:
     resolution: {integrity: sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.27.0:
     resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.27.0:
     resolution: {integrity: sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.27.0:
     resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
@@ -14212,16 +14360,16 @@ snapshots:
     dependencies:
       remove-accents: 0.5.0
 
-  '@tanstack/query-core@4.39.1': {}
+  '@tanstack/query-core@4.40.0': {}
 
   '@tanstack/query-core@5.79.0': {}
 
   '@tanstack/query-devtools@5.76.0': {}
 
-  '@tanstack/react-query-devtools@4.39.1(@tanstack/react-query@4.39.1(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@tanstack/react-query-devtools@4.40.0(@tanstack/react-query@4.40.0(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@tanstack/match-sorter-utils': 8.19.4
-      '@tanstack/react-query': 4.39.1(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)
+      '@tanstack/react-query': 4.40.0(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       superjson: 1.13.3
@@ -14245,18 +14393,18 @@ snapshots:
       next: 15.3.3(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
 
-  '@tanstack/react-query@4.39.1(react-dom@18.3.1(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)':
+  '@tanstack/react-query@4.40.0(react-dom@18.3.1(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@tanstack/query-core': 4.39.1
+      '@tanstack/query-core': 4.40.0
       react: 19.1.0
       use-sync-external-store: 1.2.2(react@19.1.0)
     optionalDependencies:
       react-dom: 18.3.1(react@19.1.0)
       react-native: 0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0)
 
-  '@tanstack/react-query@4.39.1(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)':
+  '@tanstack/react-query@4.40.0(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@tanstack/query-core': 4.39.1
+      '@tanstack/query-core': 4.40.0
       react: 19.1.0
       use-sync-external-store: 1.2.2(react@19.1.0)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^15.3.3
       version: 15.3.3
     prettier-plugin-tailwindcss:
-      specifier: ^0.6.12
-      version: 0.6.12
+      specifier: ^0.6.13
+      version: 0.6.13
     sharp:
       specifier: ^0.34.2
       version: 0.34.2
@@ -320,7 +320,7 @@ importers:
         version: 1.3.0
       prettier-plugin-tailwindcss:
         specifier: 'catalog:'
-        version: 0.6.12(prettier@3.5.3)
+        version: 0.6.13(prettier@3.5.3)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.8
@@ -369,7 +369,7 @@ importers:
         version: 19.1.2(@types/react@19.1.6)
       prettier-plugin-tailwindcss:
         specifier: 'catalog:'
-        version: 0.6.12(prettier@3.5.3)
+        version: 0.6.13(prettier@3.5.3)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.8
@@ -488,7 +488,7 @@ importers:
         version: 19.1.2(@types/react@19.1.6)
       prettier-plugin-tailwindcss:
         specifier: 'catalog:'
-        version: 0.6.12(prettier@3.5.3)
+        version: 0.6.13(prettier@3.5.3)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.8
@@ -8573,8 +8573,8 @@ packages:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
 
-  prettier-plugin-tailwindcss@0.6.12:
-    resolution: {integrity: sha512-OuTQKoqNwV7RnxTPwXWzOFXy6Jc4z8oeRZYGuMpRyG3WbuR3jjXdQFK8qFBMBx8UHWdHrddARz2fgUenild6aw==}
+  prettier-plugin-tailwindcss@0.6.13:
+    resolution: {integrity: sha512-uQ0asli1+ic8xrrSmIOaElDu0FacR4x69GynTh2oZjFY10JUt6EEumTQl5tB4fMeD6I1naKd+4rXQQ7esT2i1g==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
@@ -20759,7 +20759,7 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier-plugin-tailwindcss@0.6.12(prettier@3.5.3):
+  prettier-plugin-tailwindcss@0.6.13(prettier@3.5.3):
     dependencies:
       prettier: 3.5.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
   "sharp": "^0.34.2"
 
   # tailwindcss
-  "prettier-plugin-tailwindcss": "^0.6.12"
+  "prettier-plugin-tailwindcss": "^0.6.13"
   "@tailwindcss/postcss": "^4.1.8"
   "tailwindcss": "^4.1.8"
   "clsx": "^2.1.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,8 +46,8 @@ catalogs:
 
   # react-query
   react-query4:
-    "@tanstack/react-query": "^4.39.1"
-    "@tanstack/react-query-devtools": "^4.39.1"
+    "@tanstack/react-query": "4.40.0"
+    "@tanstack/react-query-devtools": "4.40.0"
 
   react-query5:
     "@tanstack/react-query": "^5.79.0"


### PR DESCRIPTION
# PeerDep @tanstack/react-query to version 4.40.0 and deprecate old options

<!--
    A clear and concise description of what this pr is about.
 -->
 
@ha1fstack (issue reporter), could you review these changes, please?

- Updated dependencies for @tanstack/react-query and related packages to version 4.40.0 in pnpm-lock.yaml and pnpm-workspace.yaml.
- Adjusted peer dependencies in package.json to reflect the new version.
- Deprecated certain options and types in the react-query-4 package to align with the latest API changes.
- Updated tests to accommodate changes in type expectations and removed unused imports.

Next thing to do: https://github.com/TanStack/query/pull/9334

After several years of polishing the Suspensive React Query interface — from raising the first issue to this PR and finally merging into TanStack Query v4 — it feels like we’re nearing the end of a long journey of Suspensive React Query. 감성적이게 되는 날입니다 🥲

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
