### PR TITLE
fix(react): Fix ordering of onError handlers

### DIFF
--- a/packages/react/src/lazy.ts
+++ b/packages/react/src/lazy.ts
@@ -44,13 +44,13 @@ const createLazy =
     load: () => Promise<void>
   } => {
     const composedOnSuccess = ({ load }: { load: () => Promise<void> }) => {
-      defaultOptions.onSuccess?.({ load })
       options?.onSuccess?.({ load })
+      defaultOptions.onSuccess?.({ load })
     }
 
     const composedOnError = ({ error, load }: { error: unknown; load: () => Promise<void> }) => {
-      defaultOptions.onError?.({ error, load })
       options?.onError?.({ error, load })
+      defaultOptions.onError?.({ error, load })
     }
 
     const loadNoReturn = () => load().then(noop)


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Fix ordering of `onError` handlers.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
