### PR TITLE
chore(tsup): Do minify build output

### DIFF
--- a/configs/tsup/src/index.ts
+++ b/configs/tsup/src/index.ts
@@ -8,6 +8,7 @@ export const options: Options = {
   outDir: 'dist',
   sourcemap: true,
   dts: true,
+  minify: true,
 }
 
 export const scriptOptions: Options = {


### PR DESCRIPTION
<img width="1992" height="1272" alt="Screenshot 2025-07-29 at 08 41 48" src="https://github.com/user-attachments/assets/4f36e86c-989d-4df5-8398-98e7acfab502" />
<img width="1992" height="1272" alt="Screenshot 2025-07-29 at 08 40 55" src="https://github.com/user-attachments/assets/a067327a-1637-401d-b8e3-782e053be7d4" />

It drops down size of build output.