### PR TITLE
feat(codemods): remove deprecated imports for react-query-4

### DIFF
--- a/packages/codemods/src/transforms/tanstack-query-import.ts
+++ b/packages/codemods/src/transforms/tanstack-query-import.ts
@@ -16,6 +16,13 @@ const IMPORT_TO_CHANGE = [
   'infiniteQueryOption',
 ]
 
+const REMOVE_DEPRECATED_IMPORTS = [
+  'SelectedInfiniteOptions',
+  'UnSelectedInfiniteOptions',
+  'SelectedQueryOptions',
+  'UnSelectedQueryOptions',
+]
+
 export default function transform(file: FileInfo): string {
   const j = createParserFromPath(file.path)
   const root = j(file.source)
@@ -33,7 +40,9 @@ export default function transform(file: FileInfo): string {
         IMPORT_TO_CHANGE.includes(specifier.local?.name ?? '')
       )
       const importsNamesRemained = importSpecifiers.filter(
-        (specifier) => !IMPORT_TO_CHANGE.includes(specifier.local?.name ?? '')
+        (specifier) =>
+          !IMPORT_TO_CHANGE.includes(specifier.local?.name ?? '') &&
+          !REMOVE_DEPRECATED_IMPORTS.includes(specifier.local?.name ?? '')
       )
 
       if (importNamesToChange.length > 0) {
@@ -54,7 +63,42 @@ export default function transform(file: FileInfo): string {
 
       j(path).remove()
     })
-    .toSource()
+
+  root.find(j.ExportNamedDeclaration).forEach((path) => {
+    if (path.node.specifiers) {
+      const exportSpecifiers = path.node.specifiers
+
+      const exportNamesToChange = exportSpecifiers.filter((specifier) =>
+        IMPORT_TO_CHANGE.includes(specifier.local?.name ?? '')
+      )
+      const exportNamesRemained = exportSpecifiers.filter(
+        (specifier) =>
+          !IMPORT_TO_CHANGE.includes(specifier.local?.name ?? '') &&
+          !REMOVE_DEPRECATED_IMPORTS.includes(specifier.local?.name ?? '')
+      )
+
+      if (exportNamesToChange.length > 0) {
+        const newExportStatement = j.exportNamedDeclaration(null, exportNamesToChange)
+        path.insertBefore(newExportStatement)
+      }
+      if (exportNamesRemained.length > 0) {
+        const remainingExportStatement = j.exportNamedDeclaration(null, exportNamesRemained)
+        path.insertBefore(remainingExportStatement)
+      }
+
+      j(path).remove()
+    }
+  })
+
+  REMOVE_DEPRECATED_IMPORTS.forEach((deprecatedType) => {
+    root
+      .find(j.TSTypeReference, {
+        typeName: { name: deprecatedType },
+      })
+      .remove()
+
+    root.find(j.Identifier, { name: deprecatedType }).remove()
+  })
 
   return root.toSource()
 }

--- a/packages/codemods/src/transforms/testfixtures/tanstack-query-import/tanstack-query-import.input.jsx
+++ b/packages/codemods/src/transforms/testfixtures/tanstack-query-import/tanstack-query-import.input.jsx
@@ -1,2 +1,2 @@
-import { queryOptions } from "@suspensive/react-query";
-export { queryOptions }
+import { queryOptions, useSuspenseQuery, UseSuspenseQueryResult, SelectedInfiniteOptions, UnSelectedInfiniteOptions, SelectedQueryOptions, UnSelectedQueryOptions } from "@suspensive/react-query";
+export { queryOptions, useSuspenseQuery, UseSuspenseQueryResult, SelectedInfiniteOptions, UnSelectedInfiniteOptions, SelectedQueryOptions, UnSelectedQueryOptions }

--- a/packages/codemods/src/transforms/testfixtures/tanstack-query-import/tanstack-query-import.output.jsx
+++ b/packages/codemods/src/transforms/testfixtures/tanstack-query-import/tanstack-query-import.output.jsx
@@ -1,2 +1,2 @@
-import { queryOptions } from "@tanstack/react-query";
-export { queryOptions }
+import { queryOptions, useSuspenseQuery, UseSuspenseQueryResult } from "@tanstack/react-query";
+export { queryOptions, useSuspenseQuery, UseSuspenseQueryResult };


### PR DESCRIPTION
# Overview

ref: https://github.com/toss/suspensive/pull/1639/files#diff-a31f4f5db7a67ee09e0da17e94889d0e2f610a2c7643ac6348a762acab76b882

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
