### PR TITLE
docs: fix typo `Sate Management` to `State Management` in architecture diagram

### DIFF
--- a/docs/suspensive.org/src/content/en/docs/introduction.mdx
+++ b/docs/suspensive.org/src/content/en/docs/introduction.mdx
@@ -100,7 +100,7 @@ C[useSuspenseQuery, SuspenseQuery];
 D[useSuspenseInfiniteQuery, SuspenseInfiniteQuery];
 E[useSuspenseQueries, SuspenseQueries];
 end
-subgraph BB [Sate Management @suspensive/jotai]
+subgraph BB [State Management @suspensive/jotai]
 F[Atom];
 G[AtomValue];
 end

--- a/docs/suspensive.org/src/content/ko/docs/introduction.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/introduction.mdx
@@ -100,7 +100,7 @@ C[useSuspenseQuery, SuspenseQuery];
 D[useSuspenseInfiniteQuery, SuspenseInfiniteQuery];
 E[useSuspenseQueries, SuspenseQueries];
 end
-subgraph BB [Sate Management @suspensive/jotai]
+subgraph BB [State Management @suspensive/jotai]
 F[Atom];
 G[AtomValue];
 end


### PR DESCRIPTION
# Overview

This PR corrects a typo in the architecture diagram section by changing `Sate Management` to the proper term `State Management`. This improves documentation clarity and professionalism.

## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
