### PR TITLE
docs: correct typo `Errorboundary` to `ErrorBoundary` and `hoc` to `HOC` in migration guide

### DIFF
--- a/docs/suspensive.org/src/content/en/docs/react/migration/migrate-to-v2.mdx
+++ b/docs/suspensive.org/src/content/en/docs/react/migration/migrate-to-v2.mdx
@@ -6,7 +6,7 @@
 
 A new feature that wraps a component in `<Suspense/>`, `<ErrorBoundary/>`, and `<ErrorBoundaryGroup/>` all at once.
 
-For `<Suspense/>`, `<ErrorBoundary/>`, `<ErrorBoundaryGroup/>`, etc. many people use hoc to wrap these around a component. This is because these components require some processing on their children. So, in order to not unnecessarily divide components and create depth, we use the hocs for each interface, withErrorBoundary, withErrorBoundaryGroup, and withSuspense, but as we often use each hoc in combination, we also need to improve readability. To improve this, we decided to provide wrap.
+For `<Suspense/>`, `<ErrorBoundary/>`, `<ErrorBoundaryGroup/>`, etc. many people use HOC to wrap these around a component. This is because these components require some processing on their children. So, in order to not unnecessarily divide components and create depth, we use the HOCs for each interface, withErrorBoundary, withErrorBoundaryGroup, and withSuspense, but as we often use each HOC in combination, we also need to improve readability. To improve this, we decided to provide wrap.
 
 ```jsx
 import { wrap } from '@suspensive/react'
@@ -136,26 +136,26 @@ We removed `<AsyncBoundary/>` in v2. [#295](https://github.com/toss/suspensive/i
 
 Because `<AsyncBoundary/>` uses `<ErrorBoundary/>` internally, it can be used with `useErrorBoundary` and is affected by `<ErrorBoundaryGroup/>`. We decided to remove this component from v2, believing that it would be better for maintainability and interface unification for library users.
 
-`<AsyncBoundary/>`'s feature is just wrap two component(`<Suspense/>`, `<Errorboundary/>`) by one.
+`<AsyncBoundary/>`'s feature is just wrap two component(`<Suspense/>`, `<ErrorBoundary/>`) by one.
 So, you can split by two like this.
 
 ```diff
-+ import { Suspense, Errorboundary } from '@suspensive/react'
++ import { Suspense, ErrorBoundary } from '@suspensive/react'
 - import { AsyncBoundary } from '@suspensive/react'
 
-+ <Errorboundary fallback={<Error />} onError={onError} onReset={onReset}>
++ <ErrorBoundary fallback={<Error />} onError={onError} onReset={onReset}>
 +   <Suspense fallback={<Loading />}>
 +     <Children />
 +   </Suspense>
-+ </Errorboundary>
++ </ErrorBoundary>
 - <AsyncBoundary pendingFallback={<Loading />} rejectedFallback={<Error />} onError={onError} onReset={onReset}>
 -   <Children />
 - </AsyncBoundary>
 ```
 
-### Removed `withSuspense`, `withDelay`, `withErrorboundary`, `withErrorBoundaryGroup`
+### Removed `withSuspense`, `withDelay`, `withErrorBoundary`, `withErrorBoundaryGroup`
 
-These all hocs can be replaced beautifully by new hoc builder [`wrap`](/docs/react/wrap) in v2.
+These all HOCs can be replaced beautifully by new HOC builder [`wrap`](/docs/react/wrap) in v2.
 
 ```diff
 + import { wrap } from '@suspensive/react'

--- a/docs/suspensive.org/src/content/ko/docs/react/migration/migrate-to-v2.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/react/migration/migrate-to-v2.mdx
@@ -6,7 +6,7 @@
 
 컴포넌트를 `<Suspense/>`, `<ErrorBoundary/>`, `<ErrorBoundaryGroup/>`으로 한번에 래핑하는 새로운 기능입니다.
 
-`<Suspense/>`, `<ErrorBoundary/>`, `<ErrorBoundaryGroup/>` 등의 경우 많은 사람들이 hoc를 사용하여 이러한 구성 요소를 구성 요소 주위에 래핑합니다. 이 컴포넌트들은 children에 어떤 처리를 요하기 때문입니다. 그래서 컴포넌트를 불필요하게 나누지 않고 depth를 만들지 않기 위해 각 interface를 위한 hoc인 withErrorBoundary, withErrorBoundaryGroup, withSuspense를 사용하지만 각 hoc를 조합해서 사용하는 경우도 자주 발생하면서 가독성 또한 개선할 필요가 있었습니다. 이를 개선하기 위해 wrap을 제공하기로 했습니다.
+`<Suspense/>`, `<ErrorBoundary/>`, `<ErrorBoundaryGroup/>` 등의 경우 많은 사람들이 HOC를 사용하여 이러한 구성 요소를 구성 요소 주위에 래핑합니다. 이 컴포넌트들은 children에 어떤 처리를 요하기 때문입니다. 그래서 컴포넌트를 불필요하게 나누지 않고 depth를 만들지 않기 위해 각 interface를 위한 HOC인 withErrorBoundary, withErrorBoundaryGroup, withSuspense를 사용하지만 각 HOC를 조합해서 사용하는 경우도 자주 발생하면서 가독성 또한 개선할 필요가 있었습니다. 이를 개선하기 위해 wrap을 제공하기로 했습니다.
 
 ```jsx
 import { wrap } from '@suspensive/react'
@@ -136,26 +136,26 @@ v2에서는 `<AsyncBoundary/>`를 제거했습니다. [#295](https://github.com/
 
 `<AsyncBoundary/>`는 내부적으로 `<ErrorBoundary/>`를 사용하기 때문에 `useErrorBoundary`와 함께 사용할 수 있으며 `<ErrorBoundaryGroup/>`의 영향을 받습니다. 우리는 라이브러리 사용자를 위한 유지 관리 및 인터페이스 통합에 더 좋을 것이라고 믿고 이 구성 요소를 v2에서 제거하기로 결정했습니다.
 
-`<AsyncBoundary/>`의 기능은 두 컴포넌트(`<Suspense/>`, `<Errorboundary/>`)를 하나씩 래핑하는 것입니다.
+`<AsyncBoundary/>`의 기능은 두 컴포넌트(`<Suspense/>`, `<ErrorBoundary/>`)를 하나씩 래핑하는 것입니다.
 그러면 이렇게 2개로 나눌 수 있습니다.
 
 ```diff
-+ import { Suspense, Errorboundary } from '@suspensive/react'
++ import { Suspense, ErrorBoundary } from '@suspensive/react'
 - import { AsyncBoundary } from '@suspensive/react'
 
-+ <Errorboundary fallback={<Error />} onError={onError} onReset={onReset}>
++ <ErrorBoundary fallback={<Error />} onError={onError} onReset={onReset}>
 +   <Suspense fallback={<Loading />}>
 +     <Children />
 +   </Suspense>
-+ </Errorboundary>
++ </ErrorBoundary>
 - <AsyncBoundary pendingFallback={<Loading />} rejectedFallback={<Error />} onError={onError} onReset={onReset}>
 -   <Children />
 - </AsyncBoundary>
 ```
 
-### `withSuspense`, `withDelay`, `withErrorboundary`, `withErrorBoundaryGroup` 제거
+### `withSuspense`, `withDelay`, `withErrorBoundary`, `withErrorBoundaryGroup` 제거
 
-이러한 모든 hoc는 v2의 새로운 hoc 빌더 `wrap`으로 아름답게 대체될 수 있습니다.
+이러한 모든 HOC는 v2의 새로운 HOC 빌더 `wrap`으로 아름답게 대체될 수 있습니다.
 
 ```diff
 + import { wrap } from '@suspensive/react'


### PR DESCRIPTION
# Overview

This PR updates the Suspensive v2 migration guide by fixing the capitalization of 'Errorboundary' to 'ErrorBoundary' and 'hoc' to 'HOC' for consistency with common conventions and to improve readability.
## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
