### PR TITLE
docs: fix duplicated comma in opacity style inside Delay render prop example

### DIFF
--- a/docs/suspensive.org/src/content/ko/docs/react/Delay.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/react/Delay.mdx
@@ -54,7 +54,7 @@ export const Example = () => {
       {({ isDelayed }) => (
         <div
           style={{
-            opacity: isDelayed ? 1 : 0,,
+            opacity: isDelayed ? 1 : 0,
             transition: 'opacity 1500ms',
           }}
         ></div>


### PR DESCRIPTION
# Overview

This PR fixes a minor typo in the Delay component documentation where a duplicated comma was present in the style object for opacity within the render prop example. Removing this comma improves code correctness and example clarity.

## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
