### PR TITLE
docs: move key prop from inner div to InView component for correct usage

### DIFF
--- a/docs/suspensive.org/src/content/en/docs/react-dom/InView.mdx
+++ b/docs/suspensive.org/src/content/en/docs/react-dom/InView.mdx
@@ -56,6 +56,7 @@ export const Example = () => {
     <>
       {Array.from({ length: 100 }).map((_, index) => (
         <InView
+          key={index}
           onInView={() => setInViewIndexes((prev) => [...prev, index])}
           onInViewEnd={() =>
             setInViewIndexes((prev) => prev.filter((i) => i !== index))
@@ -63,7 +64,6 @@ export const Example = () => {
         >
           {({ ref, isInView }) => (
             <div
-              key={index}
               ref={ref}
               style={{
                 backgroundColor: isInView ? 'lightblue' : 'orange',
@@ -98,10 +98,9 @@ import { InView } from '@suspensive/react-dom'
 
 export const Example = () =>
   Array.from({ length: 100 }).map((_, index) => (
-    <InView threshold={0.5}>
+    <InView key={index} threshold={0.5}>
       {({ ref, isInView }) => (
         <div
-          key={index}
           ref={ref}
           style={{
             backgroundColor: isInView ? 'lightblue' : 'orange',
@@ -130,10 +129,9 @@ import { InView } from '@suspensive/react-dom'
 
 export const Example = () =>
   Array.from({ length: 100 }).map((_, index) => (
-    <InView triggerOnce>
+    <InView key={index} triggerOnce>
       {({ ref, isInView }) => (
         <div
-          key={index}
           ref={ref}
           style={{
             backgroundColor: isInView ? 'lightblue' : 'orange',
@@ -167,10 +165,9 @@ export const Example = () => (
       <div>
         <h1>skip: {isDelayed ? 'true' : 'false'}</h1>
         {Array.from({ length: 100 }).map((_, index) => (
-          <InView skip={isDelayed}>
+          <InView key={index} skip={isDelayed}>
             {({ ref, isInView }) => (
               <div
-                key={index}
                 ref={ref}
                 style={{
                   backgroundColor: isInView ? 'lightblue' : 'orange',
@@ -203,10 +200,9 @@ import { InView } from '@suspensive/react-dom'
 
 export const Example = () =>
   Array.from({ length: 100 }).map((_, index) => (
-    <InView delay={500}>
+    <InView key={index} delay={500}>
       {({ ref, isInView }) => (
         <div
-          key={index}
           ref={ref}
           style={{
             backgroundColor: isInView ? 'lightblue' : 'orange',

--- a/docs/suspensive.org/src/content/ko/docs/react-dom/InView.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/react-dom/InView.mdx
@@ -56,6 +56,7 @@ export const Example = () => {
     <>
       {Array.from({ length: 100 }).map((_, index) => (
         <InView
+          key={index}
           onInView={() => setInViewIndexes((prev) => [...prev, index])}
           onInViewEnd={() =>
             setInViewIndexes((prev) => prev.filter((i) => i !== index))
@@ -63,7 +64,6 @@ export const Example = () => {
         >
           {({ ref, isInView }) => (
             <div
-              key={index}
               ref={ref}
               style={{
                 backgroundColor: isInView ? 'lightblue' : 'orange',
@@ -98,10 +98,9 @@ import { InView } from '@suspensive/react-dom'
 
 export const Example = () =>
   Array.from({ length: 100 }).map((_, index) => (
-    <InView threshold={0.5}>
+    <InView key={index} threshold={0.5}>
       {({ ref, isInView }) => (
         <div
-          key={index}
           ref={ref}
           style={{
             backgroundColor: isInView ? 'lightblue' : 'orange',
@@ -130,10 +129,9 @@ import { InView } from '@suspensive/react-dom'
 
 export const Example = () =>
   Array.from({ length: 100 }).map((_, index) => (
-    <InView triggerOnce>
+    <InView key={index} triggerOnce>
       {({ ref, isInView }) => (
         <div
-          key={index}
           ref={ref}
           style={{
             backgroundColor: isInView ? 'lightblue' : 'orange',
@@ -167,10 +165,9 @@ export const Example = () => (
       <div>
         <h1>skip: {isDelayed ? 'true' : 'false'}</h1>
         {Array.from({ length: 100 }).map((_, index) => (
-          <InView skip={isDelayed}>
+          <InView key={index} skip={isDelayed}>
             {({ ref, isInView }) => (
               <div
-                key={index}
                 ref={ref}
                 style={{
                   backgroundColor: isInView ? 'lightblue' : 'orange',
@@ -203,10 +200,9 @@ import { InView } from '@suspensive/react-dom'
 
 export const Example = () =>
   Array.from({ length: 100 }).map((_, index) => (
-    <InView delay={500}>
+    <InView key={index} delay={500}>
       {({ ref, isInView }) => (
         <div
-          key={index}
           ref={ref}
           style={{
             backgroundColor: isInView ? 'lightblue' : 'orange',


### PR DESCRIPTION
# Overview

Currently, the `key` prop is set on the div inside the `InView` render prop, which can cause React warnings or unexpected behavior. This PR moves the `key` prop to the `InView` component itself, which is the correct place for list keys.

## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
