### PR TITLE
docs: correct data access in useQueries suspense example to use query1.data, query2.data

### DIFF
--- a/docs/suspensive.org/src/content/en/docs/react-query/useSuspenseQueries.mdx
+++ b/docs/suspensive.org/src/content/en/docs/react-query/useSuspenseQueries.mdx
@@ -146,10 +146,10 @@ const Example = () => {
   query2.data // TData | undefined
 
   if (query1.isSuccess) {
-    query.data // TData
+    query1.data // TData
   }
   if (query2.isSuccess) {
-    query.data // TData
+    query2.data // TData
   }
 }
 ```

--- a/docs/suspensive.org/src/content/ko/docs/react-query/useSuspenseQueries.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/react-query/useSuspenseQueries.mdx
@@ -146,10 +146,10 @@ const Example = () => {
   query2.data // TData | undefined
 
   if (query1.isSuccess) {
-    query.data // TData
+    query1.data // TData
   }
   if (query2.isSuccess) {
-    query.data // TData
+    query2.data // TData
   }
 }
 ```


### PR DESCRIPTION
# Overview

This PR fixes the useQueries example in the documentation, changing from `query.data` to `query1.data` and `query2.data` to correctly reference the respective queries' data. This change improves accuracy and reduces confusion for users.

## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
