### PR TITLE
docs: export Post type for usage in PostListItem component example

### DIFF
--- a/docs/suspensive.org/src/content/en/docs/react-query/SuspenseInfiniteQuery.mdx
+++ b/docs/suspensive.org/src/content/en/docs/react-query/SuspenseInfiniteQuery.mdx
@@ -121,7 +121,7 @@ export const postsInfiniteQueryOptions = () =>
 ```
 
 ```tsx api.ts
-type Post = {
+export type Post = {
   userId: number
   id: number
   title: string

--- a/docs/suspensive.org/src/content/ko/docs/react-query/SuspenseInfiniteQuery.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/react-query/SuspenseInfiniteQuery.mdx
@@ -121,7 +121,7 @@ export const postsInfiniteQueryOptions = () =>
 ```
 
 ```tsx api.ts
-type Post = {
+export type Post = {
   userId: number
   id: number
   title: string


### PR DESCRIPTION
# Overview

This PR modifies the Post type definition by adding the export keyword so that it can be imported and used in the PostListItem component example and other parts of the codebase. This improves example correctness and usage clarity.

## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
