### PR TITLE
docs: correct typo 'QueryClinet' to 'QueryClient' in QueryClientConsumer example code

### DIFF
--- a/docs/suspensive.org/src/content/ko/docs/react-query/QueryClientConsumer.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/react-query/QueryClientConsumer.mdx
@@ -60,7 +60,7 @@ const Example = () => {
   return (
       {/* 5️⃣ @tanstack/react-query v5을 사용하신다면 props.queryClient를 사용할 수 있습니다. */}
       <QueryClientConsumer queryClient={queryClient}>
-        {(queryClient) => (<>{/* props.queryClient로 전달된 QueryClinet를 사용합니다. */}</>)}
+        {(queryClient) => (<>{/* props.queryClient로 전달된 QueryClient를 사용합니다. */}</>)}
       </QueryClientConsumer>
   )
 }


### PR DESCRIPTION
# Overview

This PR fixes a minor typo in the QueryClientConsumer example where 'QueryClinet' was mistakenly written. The correction improves documentation accuracy and avoids confusion.

## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
