### PR TITLE
docs: fix mutation example isPending usage and unify content parameter in API calls

### DIFF
--- a/docs/suspensive.org/src/content/en/docs/react-query/Mutation.mdx
+++ b/docs/suspensive.org/src/content/en/docs/react-query/Mutation.mdx
@@ -29,7 +29,7 @@ const PostsPage = () => {
             >
               {commentMutation => (
                 <div>
-                  {postMutation.isLoading ? <Spinner/> : null}
+                  {postMutation.isPending ? <Spinner/> : null}
                   {comment.content}
                   <textarea onChange={e => commentMutation.mutateAsync({ content: e.target.value })} />
                 </div>
@@ -62,7 +62,7 @@ const PostToUseMutation = ({ post }: { post: Post }) => { // Props need to be pa
     mutationFn: ({ content }: { content: string }) => api.editPost({ postId: post.id, content }),
   });
 
-  if (postMutation.isLoading) {
+  if (postMutation.isPending) {
     return <Spinner />;
   }
 

--- a/docs/suspensive.org/src/content/ko/docs/react-query/Mutation.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/react-query/Mutation.mdx
@@ -29,7 +29,7 @@ const PostsPage = () => {
             >
               {commentMutation => (
                 <div>
-                  {postMutation.isLoading ? <Spinner/> : null}
+                  {postMutation.isPending ? <Spinner/> : null}
                   {comment.content}
                   <textarea onChange={e => commentMutation.mutateAsync({ content: e.target.value })} />
                 </div>
@@ -59,10 +59,10 @@ const PostsPage = () => {
 // PostToUseMutation (불필요한 이름, useMutation만 사용하도록 변경 필요)
 const PostToUseMutation = ({ post }: { post: Post }) => { // props는 useMutation을 사용하기 위해 전달되어야 합니다.
   const postMutation = useMutation({
-    mutationFn: ({ content }: { content: string }) => api.editPost({ postId: post.id }),
+    mutationFn: ({ content }: { content: string }) => api.editPost({ postId: post.id, content }),
   });
 
-  if (postMutation.isLoading) {
+  if (postMutation.isPending) {
     return <Spinner />;
   }
 
@@ -80,7 +80,7 @@ const PostToUseMutation = ({ post }: { post: Post }) => { // props는 useMutatio
 // CommentToUseMutation (불필요한 이름, useMutation만 사용하도록 변경 필요)
 const CommentToUseMutation = ({ post, comment }: { post: Post, comment: Comment }) => { // props는 useMutation을 사용하기 위해 전달되어야 합니다.
   const commentMutation = useMutation({
-    mutationFn: ({ content }: { content: string }) => api.editComment({ postId: post.id, commentId: comment.id, comment }),
+    mutationFn: ({ content }: { content: string }) => api.editComment({ postId: post.id, commentId: comment.id, content }),
   });
 
   return (


### PR DESCRIPTION
# Overview

- Changed `postMutation.isLoading` to `postMutation.isPending` to match current API.
  <img width="598" height="281" alt="스크린샷 2025-08-25 오후 5 46 54" src="https://github.com/user-attachments/assets/8b8b05e7-8981-406a-9a6e-0ac6418c0ee4" />

- Added missing `content` parameter in `api.editPost` call to ensure correctness.
- Corrected `api.editComment` calls to pass `content` parameter consistently instead of `comment`.

These changes improve the accuracy and consistency of the mutation example in the documentation.

## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
