### PR TITLE
docs: simplify sentence by removing duplicated '공식문서' wording

### DIFF
--- a/docs/suspensive.org/src/content/ko/docs/react-query/motivation.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/react-query/motivation.mdx
@@ -66,7 +66,7 @@ TanStack 공식문서에 등록된 커뮤니티 리소스인 만큼 저희 Suspe
 
 ![TanStack Query Community Resources](/img/react-query_community-resources.png)
 
-공식문서를 통해 당신의 팀원들이 이해하기 쉬운 공식문서를 제공하고 있고 이슈가 있을 경우 신속하게 지원합니다.
+당신의 팀원들이 이해하기 쉬운 공식문서를 제공하고 있고 이슈가 있을 경우 신속하게 지원합니다.
 따라서 @tanstack/react-query v4와 함께 프로덕션 레벨에서 팀 동료들과 사용할 수 있습니다.
 
 </Steps>


### PR DESCRIPTION
# Overview

This PR changes the sentence from:

- as-is: `공식문서를 통해 당신의 팀원들이 이해하기 쉬운 공식문서를 제공하고 있고 이슈가 있을 경우 신속하게 지원합니다.`

- to-be:  `당신의 팀원들이 이해하기 쉬운 공식문서를 제공하고 있고 이슈가 있을 경우 신속하게 지원합니다.`

This reduces redundancy while preserving original meaning, improving readability and polish.

## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
