### PR TITLE
docs: update Atom docs to fix imports and improve readability

### DIFF
--- a/docs/suspensive.org/src/content/en/docs/jotai/Atom.mdx
+++ b/docs/suspensive.org/src/content/en/docs/jotai/Atom.mdx
@@ -52,7 +52,6 @@ It's not immediately clear from the parent component which atoms are used intern
 
 ```tsx
 // payment/page.tsx
-import { Atom } from '@suspensive/jotai'
 import { Suspense } from '@suspensive/react'
 import { UserInfo, ShoppingCart } from '~/components'
 
@@ -69,7 +68,6 @@ const PaymentPage = () => (
 ```tsx
 // payment/components/UserInfo.tsx
 import { useAtomValue } from '@suspensive/jotai'
-import { Suspense } from '@suspensive/react'
 import { UserAddress } from '~/components'
 import { userAsyncAtom } from '~/atoms'
 
@@ -83,8 +81,8 @@ const UserInfo = () => {
 
 ```tsx
 // payment/components/ShoppingCart.tsx
-import { Atom } from '@suspensive/jotai'
-import { Suspense } from '@suspensive/react'
+import { useAtom } from 'jotai'
+import { ShoppingItem } from '~/components'
 import { shoppingCartAtom } from '~/atoms'
 
 // It's not clear from the usage of this component what Atom ShoppingCart uses internally and whether it triggers Suspense.

--- a/docs/suspensive.org/src/content/ko/docs/jotai/Atom.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/jotai/Atom.mdx
@@ -52,7 +52,6 @@ const Example = () => (
 
 ```tsx
 // payment/page.tsx
-import { Atom } from '@suspensive/jotai'
 import { Suspense } from '@suspensive/react'
 import { UserInfo, ShoppingCart } from '~/components'
 
@@ -69,11 +68,10 @@ const PaymentPage = () => (
 ```tsx
 // payment/components/UserInfo.tsx
 import { useAtomValue } from '@suspensive/jotai'
-import { Suspense } from '@suspensive/react'
 import { UserAddress } from '~/components'
 import { userAsyncAtom } from '~/atoms'
 
-// 이 컴포넌트를 사용하는 입장에서 UserInfo라는 이름만으로 내부적으로 어떤 Atom을 사용하고, Suspense를 발생할지 예상하기 어렵습니다.
+// 이 컴포넌트를 사용하는 입장에서 UserInfo라는 이름만으로 내부적으로 어떤 Atom을 사용하고, Suspense가 발생할지 예상하기 어렵습니다.
 const UserInfo = () => {
   const data = useAtomValue(userAsyncAtom)
 
@@ -83,11 +81,11 @@ const UserInfo = () => {
 
 ```tsx
 // payment/components/ShoppingCart.tsx
-import { Atom } from '@suspensive/jotai'
-import { Suspense } from '@suspensive/react'
+import { useAtom } from 'jotai'
+import { ShoppingItem } from '~/components'
 import { shoppingCartAtom } from '~/atoms'
 
-// 이 컴포넌트를 사용하는 입장에서 ShoppingCart라는 이름만으로 내부적으로 어떤 Atom을 사용하고, Suspense를 발생할지 예상하기 어렵습니다.
+// 이 컴포넌트를 사용하는 입장에서 ShoppingCart라는 이름만으로 내부적으로 어떤 Atom을 사용하고, Suspense가 발생할지 예상하기 어렵습니다.
 const ShoppingCart = () => {
   const [data] = useAtom(shoppingCartAtom)
 


### PR DESCRIPTION
# Overview

- Removed unnecessary import of Suspense from component files where it's not used.
- Added missing imports for useAtom and ShoppingItem to reflect the usage in examples.
- Improved sentence flow by changing `Suspense를 발생할지` to `Suspense가 발생할지` for natural Korean phrasing.

These changes enhance the accuracy and readability of the Atom documentation.

## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
