### PR TITLE
ci(.github/workflows): add autofix.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: 'monthly'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,30 +1,30 @@
-"@suspensive/react":
-  - "packages/react/**/*"
-"@suspensive/react-dom":
-  - "packages/react-dom/**/*"
-"@suspensive/react-native":
-  - "packages/react-native/**/*"
-"@suspensive/react-query":
-  - "packages/react-query/**/*"
-"@suspensive/react-query-4":
-  - "packages/react-query-4/**/*"
-"@suspensive/react-query-5":
-  - "packages/react-query-5/**/*"
-"@suspensive/jotai":
-  - "packages/jotai/**/*"
-"@suspensive/codemods":
-  - "packages/codemods/**/*"
-"suspensive.org":
-  - "docs/suspensive.org/**/*"
-"examples":
-  - "examples/**/*"
-"eslint":
-  - "configs/eslint/**/*"
-  - "**/.eslint*"
-"tsconfig":
-  - "configs/tsconfig/**/*"
-  - "**/.tsconfig*"
-"dependencies":
-  - "pnpm-lock.yaml"
-"workflows":
-  - ".github/workflows/**/*"
+'@suspensive/react':
+  - 'packages/react/**/*'
+'@suspensive/react-dom':
+  - 'packages/react-dom/**/*'
+'@suspensive/react-native':
+  - 'packages/react-native/**/*'
+'@suspensive/react-query':
+  - 'packages/react-query/**/*'
+'@suspensive/react-query-4':
+  - 'packages/react-query-4/**/*'
+'@suspensive/react-query-5':
+  - 'packages/react-query-5/**/*'
+'@suspensive/jotai':
+  - 'packages/jotai/**/*'
+'@suspensive/codemods':
+  - 'packages/codemods/**/*'
+'suspensive.org':
+  - 'docs/suspensive.org/**/*'
+'examples':
+  - 'examples/**/*'
+'eslint':
+  - 'configs/eslint/**/*'
+  - '**/.eslint*'
+'tsconfig':
+  - 'configs/tsconfig/**/*'
+  - '**/.tsconfig*'
+'dependencies':
+  - 'pnpm-lock.yaml'
+'workflows':
+  - '.github/workflows/**/*'

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,5 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/pnpm-setup-node
+      - run: pnpm install
       - run: pnpm prettier --write .
       - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,23 @@
+name: autofix.ci
+
+on:
+  push:
+    branches: [main, beta, next, v1, v2, v3]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/pnpm-setup-node
+      - run: pnpm run prettier --write
+      - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,5 +19,5 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/pnpm-setup-node
-      - run: pnpm run prettier --write
+      - run: pnpm prettier --write .
       - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -9,7 +9,7 @@ jobs:
   broken-link-checker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/pnpm-setup-node
       - run: pnpm install
       - run: pnpm run blc:suspensive.org

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         command: ['prepack', 'ci:attw', 'ci:eslint', 'ci:publint', 'ci:sherif', 'ci:type', 'ci:test', 'build']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/pnpm-setup-node
       - run: pnpm install
       - if: matrix.command == 'ci:test'

--- a/.github/workflows/graph.yml
+++ b/.github/workflows/graph.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/pnpm-setup-node
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -16,7 +16,7 @@ jobs:
     name: Knip
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/pnpm-setup-node
       - run: pnpm install
       - run: pnpm run ci:knip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/pnpm-setup-node
       - run: pnpm install
       - run: |

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,8 @@
 # transforms testfixtures
 packages/codemods/src/transforms/testfixtures/**
+pnpm-lock.yaml
+**/.next
+**/coverage
+**/dist
+**/tsconfig.vitest-temp.json
+packages/**/tsup.config.bundled*.mjs

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
   },
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact", "mdx"],
   "eslint.workingDirectories": [{ "mode": "auto" }],
-  "vitest.disableWorkspaceWarning": true
+  "vitest.disableWorkspaceWarning": true,
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/packages/react/src/Delay.tsx
+++ b/packages/react/src/Delay.tsx
@@ -62,7 +62,3 @@ export const Delay = Object.assign(
       ),
   }
 )
-
-
-
-

--- a/packages/react/src/Delay.tsx
+++ b/packages/react/src/Delay.tsx
@@ -62,3 +62,7 @@ export const Delay = Object.assign(
       ),
   }
 )
+
+
+
+


### PR DESCRIPTION
I added https://autofix.ci/ to fix PRs with prettier automatically.

We can see autofix like below [db9cb51](https://github.com/toss/suspensive/pull/1716/commits/db9cb518719381cd91fe3044450d39105afab66a)

Now contributors don't have to execute `pnpm install` to format code with prettier.
I think contributors for documentation may feel easy to do something

<img width="956" height="359" alt="image" src="https://github.com/user-attachments/assets/64d5e352-b6eb-43d3-acb7-28dcd8c19d51" />

autofix ci will format automatically with prettier