### PR TITLE
ci(.github/workflows): add packlint step to autofix workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,4 +21,5 @@ jobs:
       - uses: ./.github/actions/pnpm-setup-node
       - run: pnpm install
       - run: pnpm prettier --write .
+      - run: pnpm run packlint
       - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27

--- a/examples/react-native-playground/package.json
+++ b/examples/react-native-playground/package.json
@@ -26,8 +26,8 @@
     "react-native-web": "catalog:react19"
   },
   "devDependencies": {
-    "@suspensive/eslint-config": "workspace:*",
     "@babel/core": "^7.27.1",
+    "@suspensive/eslint-config": "workspace:*",
     "@types/jest": "^29.5.14",
     "@types/react": "catalog:react19",
     "@types/react-test-renderer": "^19.0.0",


### PR DESCRIPTION
add packlint powered by @artechventure step to autofix workflow
We can see autofix ci's commit in [74633bc](https://github.com/toss/suspensive/pull/1722/commits/74633bcccd2ca9f94376eea4627180d6180d4517)

<img width="1256" height="602" alt="image" src="https://github.com/user-attachments/assets/5e7a9759-8069-4a5b-8556-da4cc8acf162" />

