### PR TITLE
chore(ci): add strip-hash option to compressed-size-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         uses: preactjs/compressed-size-action@v2
         with:
           build-script: 'prepack'
-          pattern: 'packages/*/dist/{index,v4,v5}.{js,cjs,mjs}'
+          pattern: 'packages/**/dist/*.{js,cjs,mjs}'
           exclude: '{**/*.map,**/node_modules/**}'
+          strip-hash: '-([A-Za-z0-9_-]+)\.'
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

- Add `strip-hash` option to compressed-size-action in CI workflow
- Update file pattern to track all dist files instead of specific ones
- Improve bundle size tracking accuracy after tsdown migration

### Problem
After migrating to tsdown (PR #1678), the bundle output filename format has changed significantly
- The 'chunk' files have disappeared and are now named like `dist/SuspenseQuery-DkWngpUn.cjs`
- Hash values in filenames change on every build, causing the `compressed-size-action` results to appear incorrectly
- Size comparisons were showing misleading results due to hash-based filename variations

### Solution

- Added `strip-hash` option to group files with different hashes as the same module
- Updated the file pattern from `packages/*/dist/{index,v4,v5}.{js,cjs,mjs}` to `packages/**/dist/*.{js,cjs,mjs}` to capture all dist files
- This ensures clearer bundle size tracking and more accurate size comparisons in PR comments

## PR Checklist

- [ ] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
